### PR TITLE
Use the advertising identifier instead of a random UUID when no key is specified

### DIFF
--- a/Darkly/LDUserBuilder.m
+++ b/Darkly/LDUserBuilder.m
@@ -6,6 +6,7 @@
 #import "LDUserBuilder.h"
 #import "DarklyUtil.h"
 #import "DataManager.h"
+@import AdSupport;
 
 @interface LDUserBuilder() {
     NSString *key;
@@ -188,7 +189,7 @@
         DEBUG_LOG(@"LDUserBuilder building User with key: %@", key);
         [user key:key];
     } else {
-        NSString *uniqueKey = [[NSUUID UUID] UUIDString];
+        NSString *uniqueKey = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
         DEBUG_LOG(@"LDUserBuilder building User with key: %@", uniqueKey);
         [user key:uniqueKey];
         if (!anonymous) {


### PR DESCRIPTION
@gus-byrnesinnovation The advantages of this are probably pretty minor-- but in some cases it might be useful to have the same user key for anonymous users across apps. Thoughts?