### PR TITLE
Fixed issue where if delegate was called without being set caused a

### DIFF
--- a/Darkly/LDClient.m
+++ b/Darkly/LDClient.m
@@ -24,7 +24,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         sharedLDClient = [[self alloc] init];
-        [[NSNotificationCenter defaultCenter] addObserver: self
+        [[NSNotificationCenter defaultCenter] addObserver: sharedLDClient
                                                  selector:@selector(configUpdated)
                                                      name: kLDUserUpdatedNotification object: nil];
     });
@@ -179,7 +179,9 @@
 
 // Notification handler for ClientManager user updated
 -(void)configUpdated {
-    [self.delegate userDidUpdate];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(userDidUpdate)]) {
+        [self.delegate userDidUpdate];        
+    }
 }
 
 -(void)dealloc {

--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "LaunchDarkly"
-  s.version      = "0.2.0-beta"
+  s.version      = "0.2.1-beta"
   s.summary      = "iOS SDK for LaunchDarkly"
 
   s.description  = <<-DESC
@@ -74,7 +74,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "0.2.0-beta" }
+  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "0.2.1-beta" }
 
 
 


### PR DESCRIPTION
Updated Podspec properly

Error was that it was trying to call the method on a class not the
instance.

Added additional safety net just in case the delegate gets removed before the callback returns and we could possible get a nil error exception,