### PR TITLE
Changed so that all operations touching the managedObjectContext on the

### DIFF
--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "LaunchDarkly"
-  s.version      = "0.2.2-beta"
+  s.version      = "0.2.3-beta"
   s.summary      = "iOS SDK for LaunchDarkly"
 
   s.description  = <<-DESC
@@ -74,7 +74,7 @@ Pod::Spec.new do |s|
   #  Supports git, hg, bzr, svn and HTTP.
   #
 
-  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "0.2.2-beta" }
+  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "0.2.3-beta" }
 
 
 


### PR DESCRIPTION
background thread use the contexts serial queue to execute.

Taken from:

http://stackoverflow.com/questions/9922145/what-is-nsmanagedobjectcontexts-performblock-used-for