### PR TITLE
Removed obsolete temp context as we are performing all context

### DIFF
--- a/Darkly.xcodeproj/project.pbxproj
+++ b/Darkly.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		CC4E8F431B8ABB3500F2A19D /* EventTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4E8F421B8ABB3500F2A19D /* EventTest.m */; };
 		CC4E8F461B8B3A7B00F2A19D /* UserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CC4E8F451B8B3A7B00F2A19D /* UserTest.m */; };
 		CC674C901B7519FB00B6A78D /* FeatureFlag.m in Sources */ = {isa = PBXBuildFile; fileRef = CC674C8F1B7519FB00B6A78D /* FeatureFlag.m */; };
+		CC753A231BF2FB8B001E4124 /* UserEntity+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = CC753A201BF2FB8B001E4124 /* UserEntity+CoreDataProperties.m */; };
+		CC753A281BF2FB8B001E4124 /* UserEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = CC753A221BF2FB8B001E4124 /* UserEntity.m */; };
 		CCA68A0F1B7066230052BE63 /* Event.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA68A0A1B7066230052BE63 /* Event.m */; };
 		CCA68A111B7066230052BE63 /* User.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA68A0E1B7066230052BE63 /* User.m */; };
 		CCA68A131B7066480052BE63 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCA68A121B7066480052BE63 /* CoreData.framework */; };
@@ -146,6 +148,11 @@
 		CC4E8F451B8B3A7B00F2A19D /* UserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UserTest.m; path = Models/UserTest.m; sourceTree = "<group>"; };
 		CC674C8E1B7519FB00B6A78D /* FeatureFlag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeatureFlag.h; path = Models/FeatureFlag.h; sourceTree = "<group>"; };
 		CC674C8F1B7519FB00B6A78D /* FeatureFlag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FeatureFlag.m; path = Models/FeatureFlag.m; sourceTree = "<group>"; };
+		CC753A0A1BF2E043001E4124 /* darkly2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = darkly2.xcdatamodel; sourceTree = "<group>"; };
+		CC753A1F1BF2FB8B001E4124 /* UserEntity+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UserEntity+CoreDataProperties.h"; path = "Models/UserEntity+CoreDataProperties.h"; sourceTree = "<group>"; };
+		CC753A201BF2FB8B001E4124 /* UserEntity+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UserEntity+CoreDataProperties.m"; path = "Models/UserEntity+CoreDataProperties.m"; sourceTree = "<group>"; };
+		CC753A211BF2FB8B001E4124 /* UserEntity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UserEntity.h; path = Models/UserEntity.h; sourceTree = "<group>"; };
+		CC753A221BF2FB8B001E4124 /* UserEntity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UserEntity.m; path = Models/UserEntity.m; sourceTree = "<group>"; };
 		CCA68A091B7066230052BE63 /* Event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Event.h; path = Models/Event.h; sourceTree = "<group>"; };
 		CCA68A0A1B7066230052BE63 /* Event.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Event.m; path = Models/Event.m; sourceTree = "<group>"; };
 		CCA68A0D1B7066230052BE63 /* User.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = User.h; path = Models/User.h; sourceTree = "<group>"; };
@@ -357,9 +364,21 @@
 			name = Models;
 			sourceTree = "<group>";
 		};
+		CC753A2D1BF2FBB0001E4124 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				CC753A1F1BF2FB8B001E4124 /* UserEntity+CoreDataProperties.h */,
+				CC753A201BF2FB8B001E4124 /* UserEntity+CoreDataProperties.m */,
+				CC753A211BF2FB8B001E4124 /* UserEntity.h */,
+				CC753A221BF2FB8B001E4124 /* UserEntity.m */,
+			);
+			name = CoreData;
+			sourceTree = "<group>";
+		};
 		CCA68A081B7065E50052BE63 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				CC753A2D1BF2FBB0001E4124 /* CoreData */,
 				CC674C8E1B7519FB00B6A78D /* FeatureFlag.h */,
 				CC674C8F1B7519FB00B6A78D /* FeatureFlag.m */,
 				CCA68A091B7066230052BE63 /* Event.h */,
@@ -694,8 +713,10 @@
 				CC674C901B7519FB00B6A78D /* FeatureFlag.m in Sources */,
 				3A70A7881B6FCFAC00984E23 /* LDClient.m in Sources */,
 				ADE5294F1B8418B200761F3D /* LDUserBuilder.m in Sources */,
+				CC753A281BF2FB8B001E4124 /* UserEntity.m in Sources */,
 				CCA68A111B7066230052BE63 /* User.m in Sources */,
 				CCDDE1771B7418B400DFC04B /* Config.m in Sources */,
+				CC753A231BF2FB8B001E4124 /* UserEntity+CoreDataProperties.m in Sources */,
 				CCA68A0F1B7066230052BE63 /* Event.m in Sources */,
 				3AC5D0DE1B8AA44A00417CBB /* NSDictionary+JSON.m in Sources */,
 				3A9F23D11B82D19900D0EF2F /* RequestManager.m in Sources */,
@@ -1090,9 +1111,10 @@
 		CCA68A141B7066980052BE63 /* darkly.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				CC753A0A1BF2E043001E4124 /* darkly2.xcdatamodel */,
 				CCA68A151B7066980052BE63 /* darkly.xcdatamodel */,
 			);
-			currentVersion = CCA68A151B7066980052BE63 /* darkly.xcdatamodel */;
+			currentVersion = CC753A0A1BF2E043001E4124 /* darkly2.xcdatamodel */;
 			path = darkly.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Darkly/LDUserBuilder.m
+++ b/Darkly/LDUserBuilder.m
@@ -6,6 +6,8 @@
 #import "LDUserBuilder.h"
 #import "DarklyUtil.h"
 #import "DataManager.h"
+#import "UserEntity.h"
+
 @interface LDUserBuilder() {
     NSString *key;
     NSString *ip;
@@ -173,22 +175,27 @@
     return self;
 }
 
-- (LDUserBuilder *)withAnonymous:(BOOL)inputAnonymous
-{
+- (LDUserBuilder *)withAnonymous:(BOOL)inputAnonymous {
     anonymous = inputAnonymous;
     return self;
 }
 
--(User *)build
-{
+-(User *)build {
     DEBUG_LOGX(@"LDUserBuilder build method called");
-    User *user = [[User alloc] init];
+    User *user = nil;
+    
     if (key) {
-        DEBUG_LOG(@"LDUserBuilder building User with key: %@", key);
+        user = [[DataManager sharedManager] findUserWithkey:key];
+        if(!user) {
+            user = [[User alloc] init];
+        }
         [user key:key];
+        DEBUG_LOG(@"LDUserBuilder building User with key: %@", key);
     } else {
         NSString *uniqueKey = [[[UIDevice currentDevice] identifierForVendor] UUIDString];
         DEBUG_LOG(@"LDUserBuilder building User with key: %@", uniqueKey);
+
+        user = [[User alloc] init];
         [user key:uniqueKey];
         if (!anonymous) {
             Boolean currentAnonymous = YES;
@@ -228,7 +235,7 @@
         [user setAnonymous:currentAnonymous];
     }
     DEBUG_LOG(@"LDUserBuilder building User with anonymous: %d", anonymous);
-    [[DataManager sharedManager] saveContext];
+    [[DataManager sharedManager] saveUser: user];
     return user;
 }
 

--- a/Darkly/Models/Config.m
+++ b/Darkly/Models/Config.m
@@ -20,7 +20,14 @@
 
 + (NSDictionary *)managedObjectKeysByPropertyKey {
     // mapping between NSManagaedObject and Mantle object goes here
-    return @{@"featuresJsonDictionary": @"featuresJsonDictionary"};
+    return @{@"featuresJsonDictionary": @"featuresJsonDictionary",
+             @"user": @"user"};
+}
+
++ (NSDictionary *)relationshipModelClassesByPropertyKey {
+    return @{
+             @"user" : [User class]
+             };
 }
 
 -(NSArray *)features {
@@ -67,6 +74,5 @@
         return [feature.key isEqualToString: keyName];
     }];
 }
-
 
 @end

--- a/Darkly/Models/ConfigEntity+CoreDataProperties.h
+++ b/Darkly/Models/ConfigEntity+CoreDataProperties.h
@@ -1,0 +1,24 @@
+//
+//  ConfigEntity+CoreDataProperties.h
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "ConfigEntity.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ConfigEntity (CoreDataProperties)
+
+@property (nullable, nonatomic, retain) id featuresJsonDictionary;
+@property (nullable, nonatomic, retain) NSNumber *pollTimeInSeconds;
+@property (nullable, nonatomic, retain) UserEntity *user;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Darkly/Models/ConfigEntity+CoreDataProperties.m
+++ b/Darkly/Models/ConfigEntity+CoreDataProperties.m
@@ -1,0 +1,20 @@
+//
+//  ConfigEntity+CoreDataProperties.m
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "ConfigEntity+CoreDataProperties.h"
+
+@implementation ConfigEntity (CoreDataProperties)
+
+@dynamic featuresJsonDictionary;
+@dynamic pollTimeInSeconds;
+@dynamic user;
+
+@end

--- a/Darkly/Models/ConfigEntity.h
+++ b/Darkly/Models/ConfigEntity.h
@@ -1,0 +1,24 @@
+//
+//  ConfigEntity.h
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class UserEntity;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ConfigEntity : NSManagedObject
+
+// Insert code here to declare functionality of your managed object subclass
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#import "ConfigEntity+CoreDataProperties.h"

--- a/Darkly/Models/ConfigEntity.m
+++ b/Darkly/Models/ConfigEntity.m
@@ -1,0 +1,16 @@
+//
+//  ConfigEntity.m
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+
+#import "ConfigEntity.h"
+#import "UserEntity.h"
+
+@implementation ConfigEntity
+
+// Insert code here to add functionality to your managed object subclass
+
+@end

--- a/Darkly/Models/DataManager.h
+++ b/Darkly/Models/DataManager.h
@@ -5,6 +5,9 @@
 
 #import <CoreData/CoreData.h>
 #import "User.h"
+#import "UserEntity.h"
+
+extern int const kUserCacheSize;
 
 @interface DataManager : NSObject
 @property (readonly, strong, nonatomic) NSManagedObjectContext *managedObjectContext;
@@ -22,4 +25,11 @@
 -(void) createCustomEvent: (NSString *)eventKey
 withCustomValuesDictionary: (NSDictionary *)customDict;
 -(NSArray *)allEvents;
+-(Config *) createConfigFromJsonDict: (NSDictionary *)jsonConfigDictionary;
+-(UserEntity *)findUserEntityWithkey: (NSString *)key;
+-(User *)findUserWithkey: (NSString *)key;
+-(void)purgeOldUsers;
+-(void)deleteOrphanedConfig;
+-(void) saveUser: (User *) user;
+
 @end

--- a/Darkly/Models/DataManager.m
+++ b/Darkly/Models/DataManager.m
@@ -10,18 +10,123 @@
 #import "Event.h"
 #import "DarklyUtil.h"
 
+int const kUserCacheSize = 5;
+
 @implementation DataManager
 @synthesize managedObjectContext;
 @synthesize managedObjectModel;
 @synthesize persistentStoreCoordinator;
 
 + (id)sharedManager {
-    static DataManager *sharedAPIManager = nil;
+    static DataManager *sharedDataManager = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedAPIManager = [[self alloc] init];
+        sharedDataManager = [[self alloc] init];
     });
-    return sharedAPIManager;
+    return sharedDataManager;
+}
+
+-(void)purgeOldUsers {
+    NSFetchRequest *request = [[NSFetchRequest alloc] init];
+    [request setEntity:[NSEntityDescription entityForName:@"UserEntity"
+                                   inManagedObjectContext:[self managedObjectContext]]];
+    
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"updatedAt" ascending:YES];
+    request.sortDescriptors = @[sortDescriptor];
+
+    __block NSArray *userMoArray = nil;
+
+    [self.managedObjectContext performBlockAndWait:^{
+        NSError *error = nil;
+        userMoArray = [[self managedObjectContext] executeFetchRequest:request
+                                                                  error:&error];
+        
+        if (userMoArray.count >= kUserCacheSize) {
+            int numToDelete = (int)userMoArray.count - (kUserCacheSize + 1);
+            for (int userMOIndex = 0; userMOIndex < userMoArray.count; userMOIndex++) {
+                if (userMOIndex < numToDelete) {
+                    DEBUG_LOG(@"Deleting cached User at index: %d", userMOIndex);
+                    [self.managedObjectContext deleteObject: [userMoArray objectAtIndex:userMOIndex]];
+                }
+            }
+        }
+    }];
+    [self saveContext];
+}
+
+-(void) saveUser: (User *) user {
+    UserEntity *userEntity = [[DataManager sharedManager] findUserEntityWithkey:user.key];
+    
+    if (userEntity) {
+        user.config = [MTLManagedObjectAdapter modelOfClass:[Config class] fromManagedObject: (NSManagedObject *)userEntity.config error: nil];
+    } else {
+        [[DataManager sharedManager] purgeOldUsers];
+    }
+    
+    [MTLManagedObjectAdapter managedObjectFromModel: user
+                               insertingIntoContext: [[DataManager sharedManager] managedObjectContext]
+                                              error: nil];
+    
+    [[DataManager sharedManager] saveContext];
+}
+
+-(void)deleteOrphanedConfig {
+    NSFetchRequest *request = [[NSFetchRequest alloc] init];
+    [request setEntity:[NSEntityDescription entityForName:@"ConfigEntity"
+                                   inManagedObjectContext:[self managedObjectContext]]];
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"user.key = nil"];
+    request.predicate = predicate;
+
+    __block NSArray *configMoArray = nil;
+
+    [self.managedObjectContext performBlockAndWait:^{
+        NSError *error = nil;
+        configMoArray = [[self managedObjectContext] executeFetchRequest:request
+                                                                  error:&error];
+        
+        for (int configMOIndex = 0; configMOIndex < configMoArray.count; configMOIndex++) {
+            DEBUG_LOG(@"Deleting orphaned config at index: %d", configMOIndex);
+            [self.managedObjectContext deleteObject: [configMoArray objectAtIndex:configMOIndex]];
+        }
+    }];
+}
+
+-(UserEntity *)findUserEntityWithkey:(NSString *)key {
+    DEBUG_LOG(@"Retrieving user with key: %@", key);
+    NSFetchRequest *request = [[NSFetchRequest alloc] init];
+    [request setEntity:[NSEntityDescription entityForName:@"UserEntity"
+                                   inManagedObjectContext:[self managedObjectContext]]];
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"key == %@", key];
+    request.predicate = predicate;
+
+    __block NSArray *userMoArray = nil;
+
+    [self.managedObjectContext performBlockAndWait:^{
+        NSError *error = nil;
+        userMoArray = [[self managedObjectContext] executeFetchRequest:request
+                                                                  error:&error];
+    }];
+    
+    if (userMoArray.count > 0) {
+        return userMoArray.firstObject;
+    }
+    return nil;
+}
+
+-(User *)findUserWithkey: (NSString *)key {
+    NSManagedObject *userMo = [self findUserEntityWithkey:key];
+    
+    if (userMo) {
+        NSError *error;
+        User *user = [MTLManagedObjectAdapter modelOfClass:[User class] fromManagedObject:userMo error: &error];
+        
+        NSLog(@"Error is %@", [error debugDescription]);
+        user.updatedAt = [NSDate date];
+        return user;
+    }
+    return nil;
 }
 
 -(void) createFeatureEvent: (NSString *)featureKey keyValue:(BOOL)keyValue defaultKeyValue:(BOOL)defaultKeyValue {
@@ -43,6 +148,19 @@
     [self saveContext];
 }
 
+-(Config *) createConfigFromJsonDict: (NSDictionary *)jsonConfigDictionary {
+    Config *config = [MTLJSONAdapter modelOfClass:[Config class]
+                               fromJSONDictionary:jsonConfigDictionary
+                                            error: nil];
+    
+    [MTLManagedObjectAdapter managedObjectFromModel:config
+                               insertingIntoContext:[[DataManager sharedManager] managedObjectContext]
+                                              error: nil];
+    [self saveContext];
+    
+    return config;
+}
+
 -(NSManagedObject *)findEvent: (NSInteger) date {
     DEBUG_LOG(@"Retrieving event for date: %ld", (long)date);
     NSFetchRequest *request = [[NSFetchRequest alloc] init];
@@ -50,13 +168,13 @@
                                    inManagedObjectContext:[self managedObjectContext]]];
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"creationDate == %ld", date];
     request.predicate = predicate;
-
+    
     __block NSArray *eventMoArray = nil;
     [self.managedObjectContext performBlockAndWait:^{
-
-    NSError *error = nil;
-    eventMoArray = [[self managedObjectContext] executeFetchRequest:request
-                                                                       error:&error];
+        
+        NSError *error = nil;
+        eventMoArray = [[self managedObjectContext] executeFetchRequest:request
+                                                                  error:&error];
     }];
     
     if (eventMoArray.count > 0) {
@@ -105,7 +223,7 @@
             
             NSMutableDictionary *eventsDictionary = [MTLJSONAdapter JSONDictionaryFromModel:event
                                                                                       error: nil].mutableCopy;
-            NSDictionary *jSONDictionary = currentUser.dictionaryValue;
+            NSDictionary *jSONDictionary = [MTLJSONAdapter JSONDictionaryFromModel:currentUser error: nil];
             [eventsDictionary setObject: jSONDictionary forKey: @"user"];
             [eventJsonDictArray addObject:eventsDictionary];
         }
@@ -186,12 +304,9 @@
 }
 
 -(void)saveInBackground {
-    NSManagedObjectContext *temporaryContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    temporaryContext.parentContext = [self managedObjectContext];
-
-    [temporaryContext performBlockAndWait:^{
+    [self.managedObjectContext performBlock:^{
         NSError *error = nil;
-        if (![temporaryContext save:&error])
+        if (![self.managedObjectContext save:&error])
             NSLog(@"Error saving to child context %@, %@", error, [error userInfo]);
     }];
 }

--- a/Darkly/Models/User.h
+++ b/Darkly/Models/User.h
@@ -15,6 +15,7 @@
 @property (nullable, nonatomic, strong) NSString *email;
 @property (nullable, nonatomic, strong) NSString *avatar;
 @property (nullable, nonatomic, strong) NSDictionary *custom;
+@property (nullable, nonatomic, strong) NSDate *updatedAt;
 @property (nullable, nonatomic, strong) Config *config;
 
 @property (nonatomic, assign) BOOL anonymous;

--- a/Darkly/Models/User.m
+++ b/Darkly/Models/User.m
@@ -23,6 +23,11 @@
         DEBUG_LOG(@"User building User with system version: %@", systemVersion);
         [self setOs:systemVersion];
         
+        // Need to set updated Date
+        NSDate *currentDate = [NSDate date];
+        DEBUG_LOG(@"User building User with updatedAt: %@", currentDate);
+        [self setUpdatedAt:currentDate];
+        
         self.custom = @{};
     }
     
@@ -57,8 +62,8 @@
                @"custom": @"custom",
                @"device": @"device",
                @"os": @"os",
-               @"config": @"config",
-               @"anonymous": @"anonymous"
+               @"anonymous": @"anonymous",
+               @"updatedAt": @"updatedAt"
                };
 }
 
@@ -102,14 +107,33 @@
     for (NSString *originalKey in [super dictionaryValue]) {
         id propertyValue = [self valueForKey:originalKey];
         if ( propertyValue == nil ||
-            [originalKey isEqualToString: @"config"] ||
             ([originalKey isEqualToString: @"custom"] &&
              [(NSDictionary *)propertyValue count] == 0)) {
-            [modifiedDictionaryValue removeObjectForKey:originalKey];
-        }
+                [modifiedDictionaryValue removeObjectForKey:originalKey];
+            }
     }
     
     return [modifiedDictionaryValue copy];
+}
+
++(NSValueTransformer *) updatedAtJSONTransformer {
+    return [MTLValueTransformer transformerUsingForwardBlock:^id(NSString *dateString, BOOL *success, NSError *__autoreleasing *error) {
+        return [[self dateformatter] dateFromString:dateString];
+    } reverseBlock:^id(NSDate *date, BOOL *success, NSError *__autoreleasing *error) {
+        return [[self dateformatter] stringFromDate:date];
+    }];
+}
+
++(NSDateFormatter *)dateformatter{
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.locale = [NSLocale currentLocale];
+    dateFormatter.dateStyle = NSDateFormatterMediumStyle;
+    dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
+    return dateFormatter;
+}
+
++ (NSSet *)propertyKeysForManagedObjectUniquing {
+    return [NSSet setWithObject:@"key"];
 }
 
 @end

--- a/Darkly/Models/UserEntity+CoreDataProperties.h
+++ b/Darkly/Models/UserEntity+CoreDataProperties.h
@@ -1,0 +1,34 @@
+//
+//  UserEntity+CoreDataProperties.h
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "UserEntity.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UserEntity (CoreDataProperties)
+
+@property (nullable, nonatomic, retain) NSNumber *anonymous;
+@property (nullable, nonatomic, retain) NSString *avatar;
+@property (nullable, nonatomic, retain) NSString *country;
+@property (nullable, nonatomic, retain) id custom;
+@property (nullable, nonatomic, retain) NSString *device;
+@property (nullable, nonatomic, retain) NSString *email;
+@property (nullable, nonatomic, retain) NSString *firstName;
+@property (nullable, nonatomic, retain) NSString *ip;
+@property (nullable, nonatomic, retain) NSString *key;
+@property (nullable, nonatomic, retain) NSString *lastName;
+@property (nullable, nonatomic, retain) NSString *os;
+@property (nullable, nonatomic, retain) NSDate *updatedAt;
+@property (nullable, nonatomic, retain) ConfigEntity *config;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Darkly/Models/UserEntity+CoreDataProperties.m
+++ b/Darkly/Models/UserEntity+CoreDataProperties.m
@@ -1,0 +1,30 @@
+//
+//  UserEntity+CoreDataProperties.m
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+//  Choose "Create NSManagedObject Subclass…" from the Core Data editor menu
+//  to delete and recreate this implementation file for your updated model.
+//
+
+#import "UserEntity+CoreDataProperties.h"
+
+@implementation UserEntity (CoreDataProperties)
+
+@dynamic anonymous;
+@dynamic avatar;
+@dynamic country;
+@dynamic custom;
+@dynamic device;
+@dynamic email;
+@dynamic firstName;
+@dynamic ip;
+@dynamic key;
+@dynamic lastName;
+@dynamic os;
+@dynamic updatedAt;
+@dynamic config;
+
+@end

--- a/Darkly/Models/UserEntity.h
+++ b/Darkly/Models/UserEntity.h
@@ -1,0 +1,24 @@
+//
+//  UserEntity.h
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreData/CoreData.h>
+
+@class ConfigEntity;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UserEntity : NSManagedObject
+
+// Insert code here to declare functionality of your managed object subclass
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#import "UserEntity+CoreDataProperties.h"

--- a/Darkly/Models/UserEntity.m
+++ b/Darkly/Models/UserEntity.m
@@ -1,0 +1,16 @@
+//
+//  UserEntity.m
+//  
+//
+//  Created by Constantinos Mavromoustakos on 11/10/15.
+//
+//
+
+#import "UserEntity.h"
+#import "ConfigEntity.h"
+
+@implementation UserEntity
+
+// Insert code here to add functionality to your managed object subclass
+
+@end

--- a/Darkly/darkly.xcdatamodeld/.xccurrentversion
+++ b/Darkly/darkly.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>darkly2.xcdatamodel</string>
+</dict>
+</plist>

--- a/Darkly/darkly.xcdatamodeld/darkly2.xcdatamodel/contents
+++ b/Darkly/darkly.xcdatamodeld/darkly2.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="ConfigEntity" representedClassName="ConfigEntity" syncable="YES">
         <attribute name="featuresJsonDictionary" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="pollTimeInSeconds" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
-        <relationship name="user" maxCount="1" deletionRule="Cascade" destinationEntity="UserEntity" inverseName="config" inverseEntity="UserEntity" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserEntity" inverseName="config" inverseEntity="UserEntity" syncable="YES"/>
     </entity>
     <entity name="EventEntity" syncable="YES">
         <attribute name="creationDate" optional="YES" attributeType="Integer 64" defaultValueString="0.0" syncable="YES"/>
@@ -21,12 +21,12 @@
         <attribute name="device" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="groups" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="ip" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="key" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="os" optional="YES" attributeType="String" syncable="YES"/>
-        <relationship name="config" maxCount="1" deletionRule="Cascade" destinationEntity="ConfigEntity" inverseName="user" inverseEntity="ConfigEntity" syncable="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <relationship name="config" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ConfigEntity" inverseName="user" inverseEntity="ConfigEntity" syncable="YES"/>
     </entity>
     <elements>
         <element name="ConfigEntity" positionX="-65" positionY="153" width="128" height="90"/>

--- a/DarklyTests/LDClientTest.m
+++ b/DarklyTests/LDClientTest.m
@@ -64,6 +64,30 @@
     XCTAssertTrue([[LDClient sharedInstance] toggle:@"test" default:YES]);
 }
 
+- (void)testUserPersisted {
+    NSString *testApiKey = @"testApiKey";
+    LDConfigBuilder *builder = [[LDConfigBuilder alloc] init];
+    [builder withApiKey:testApiKey];
+    
+    LDUserBuilder *userBuilder = [[LDUserBuilder alloc] init];
+    [userBuilder withKey:@"myKey"];
+    [userBuilder withEmail:@"my@email.com"];
+    
+    [[LDClient sharedInstance] start:builder userBuilder:userBuilder];
+    XCTAssertTrue([[LDClient sharedInstance] toggle:@"test" default:YES]);
+    
+    LDUserBuilder *anotherUserBuilder = [[LDUserBuilder alloc] init];
+    [anotherUserBuilder withKey:@"myKey"];
+
+    User *user = [[LDClient sharedInstance] user];
+    OCMStub([self.dataManagerMock findUserWithkey:[OCMArg any]]).andReturn(user);
+
+    [[LDClient sharedInstance] start:builder userBuilder:anotherUserBuilder];
+    user = [[LDClient sharedInstance] user];
+    
+     XCTAssertEqual(user.email, @"my@email.com");
+}
+
 -(void)testToggleCreatesEventWithCorrectArguments {
     NSString *toggleName = @"test";
     BOOL toggleDefaultValue = YES;
@@ -73,7 +97,7 @@
     OCMStub([self.dataManagerMock createFeatureEvent:[OCMArg any] keyValue:[OCMArg any] defaultKeyValue:[OCMArg any]]);
     [[LDClient sharedInstance] start:builder userBuilder:nil];
     [[LDClient sharedInstance] toggle:toggleName default:toggleDefaultValue];
-
+    
     OCMVerify([self.dataManagerMock createFeatureEvent:toggleName keyValue:toggleDefaultValue defaultKeyValue:toggleDefaultValue]);
     [self.dataManagerMock stopMocking];
 }
@@ -91,12 +115,12 @@
     
     
     OCMStub([self.dataManagerMock createCustomEvent:[OCMArg isKindOfClass:[NSString class]]  withCustomValuesDictionary:[OCMArg isKindOfClass:[NSDictionary class]]]);
-
+    
     XCTAssertTrue([[LDClient sharedInstance] track:@"test" data:customData]);
     
     OCMVerify([self.dataManagerMock createCustomEvent: @"test"
-                      withCustomValuesDictionary: customData]);
-
+                           withCustomValuesDictionary: customData]);
+    
 }
 
 - (void)testOfflineWithoutStart {
@@ -173,7 +197,7 @@
     
     ldClient.delegate = self;
     
-    XCTAssertEqualObjects(self, ldClient.delegate);    
+    XCTAssertEqualObjects(self, ldClient.delegate);
 }
 
 

--- a/DarklyTests/LDUserTest.m
+++ b/DarklyTests/LDUserTest.m
@@ -5,8 +5,11 @@
 #import <XCTest/XCTest.h>
 #import "LDUserBuilder.h"
 #import "User.h"
+#import "DataManager.h"
+#import "DarklyXCTestCase.h"
+#import <OCMock.h>
 
-@interface LDUserBuilderTest : XCTestCase
+@interface LDUserBuilderTest : DarklyXCTestCase
 
 @end
 
@@ -51,7 +54,8 @@
     builder = [builder withEmail:testEmail];
     builder = [builder withAvatar:testAvatar];
     builder = [builder withCustomString:testCustomKey value:testCustomValue];
-    builder = [builder withAnonymous:testAnonymous];
+    builder = [builder withAnonymous:testAnonymous];    
+
     User *user = [builder build];
     XCTAssertEqualObjects([user key], testKey);
     XCTAssertEqualObjects([user ip], testIp);
@@ -67,10 +71,8 @@
 }
 
 - (void)testUserSetAnonymous {
-    NSString *testKey = @"testKey";
     Boolean testAnonymous = YES;
     LDUserBuilder *builder = [[LDUserBuilder alloc] init];
-    builder = [builder withKey:testKey];
     builder = [builder withAnonymous:testAnonymous];
     User *user = [builder build];
     XCTAssertTrue([user anonymous]);

--- a/DarklyTests/Models/DataManagerTest.m
+++ b/DarklyTests/Models/DataManagerTest.m
@@ -14,6 +14,7 @@
 #import "LDClient.h"
 #import <OCMock.h>
 #import "NSArray+UnitTests.h"
+#import "UserEntity.h"
 
 @interface DataManagerTest : DarklyXCTestCase
 @property (nonatomic) id clientMock;
@@ -31,6 +32,7 @@
     user.firstName = @"Bob";
     user.lastName = @"Giffy";
     user.email = @"bob@gmail.com";
+    user.updatedAt = [NSDate date];
     
     
     LDClient *client = [LDClient sharedInstance];
@@ -157,5 +159,59 @@
     NSString *eventUserKey = [userDict objectForKey:@"email"];
 
     XCTAssertTrue([eventUserKey isEqualToString: theUser.email]);    
+}
+
+
+-(void)testFindOrCreateUser {
+    NSString *userKey = @"thisisgus";
+    User *aUser = [[User alloc] init];
+    aUser.key = userKey;
+    aUser.email = @"gus@anemail.com";
+    aUser.updatedAt = [NSDate date];
+    aUser.config = user.config;
+        
+    [MTLManagedObjectAdapter managedObjectFromModel:aUser 
+                               insertingIntoContext: [[DataManager sharedManager]
+                                                      managedObjectContext] error: nil];
+    [[DataManager sharedManager] saveContext];
+    
+    XCTAssertNotNil(aUser);
+    
+    User *foundAgainUser = [[DataManager sharedManager] findUserWithkey: userKey];
+    
+    XCTAssertNotNil(foundAgainUser);
+    XCTAssertEqual(aUser.email, foundAgainUser.email);
+}
+
+-(void) testPurgeUsers {
+    NSDate *now = [NSDate date];
+    
+    for(int index = 0; index < kUserCacheSize + 3; index++) {
+        User *aUser = [[User alloc] init];
+        aUser.key = [NSString stringWithFormat: @"gus%d", index];
+        aUser.email = @"gus@anemail.com";
+        
+        NSTimeInterval secondsInXHours = index * 60 * 60;
+        NSDate *dateInXHours = [now dateByAddingTimeInterval:secondsInXHours];
+        aUser.updatedAt = dateInXHours;
+    
+        NSError *error;
+        [MTLManagedObjectAdapter managedObjectFromModel:aUser
+                                   insertingIntoContext: [[DataManager sharedManager]
+                                                          managedObjectContext] error: &error];
+        
+        NSLog(@"PRINT BREAK");
+    }
+    
+    [self.dataManagerMock saveContext];
+    NSString *userKey = @"gus0";
+
+    UserEntity *userEntity = [[DataManager sharedManager] findUserEntityWithkey: userKey];
+
+    XCTAssertNotNil(userEntity);
+    [[DataManager sharedManager] purgeOldUsers];
+    
+    userEntity = [[DataManager sharedManager] findUserEntityWithkey: userKey];
+    XCTAssertNil(userEntity);
 }
 @end


### PR DESCRIPTION
operations using the block syntax they will be executed in the default
context queue set up for this ManagedObjectContext

Added code to store and read the config from the db. The db will be
updated and is retreived each time by overriding the User#config method
to return the first config found on the store.