### PR TITLE
Fix for crash reported in #82 

### DIFF
--- a/Darkly/LDEventModel.h
+++ b/Darkly/LDEventModel.h
@@ -17,8 +17,8 @@
 @property (nullable, nonatomic, strong) NSDictionary *data;
 @property (nullable, nonatomic, strong) LDUserModel *user;
 
-@property (nonatomic, assign) NSObject * __nonnull value;
-@property (nonatomic, assign) NSObject * __nonnull isDefault;
+@property (nonnull, nonatomic, strong) NSObject *value;
+@property (nonnull, nonatomic, strong) NSObject *isDefault;
 
 -(nonnull id)initWithDictionary:(nonnull NSDictionary *)dictionary;
 -(nonnull NSDictionary *)dictionaryValue;


### PR DESCRIPTION
Changes 'value' and 'isDefault' properties to be strongly retained to avoid crashing when having feature toggles that's of the multivariation type. Crash is mitigated when only true/false feature flags is used - which makes sense when going through the code.