### PR TITLE
Use the configured connection timeout

### DIFF
--- a/Darkly/LDClientManager.m
+++ b/Darkly/LDClientManager.m
@@ -49,7 +49,7 @@
     [pollingMgr startEventPolling];
     
     if ([config streaming]) {
-        eventSource = [EventSource eventSourceWithURL:[NSURL URLWithString:kStreamUrl] mobileKey:config.mobileKey];
+        eventSource = [EventSource eventSourceWithURL:[NSURL URLWithString:kStreamUrl] mobileKey:config.mobileKey timeoutInterval:[config.connectionTimeout doubleValue]];
         
         [eventSource onMessage:^(Event *e) {
             [self syncWithServerForConfig];

--- a/Darkly/LDRequestManager.m
+++ b/Darkly/LDRequestManager.m
@@ -53,6 +53,7 @@ static NSString * const kEventRequestCompletedNotification = @"event_request_com
             requestUrl = [requestUrl stringByAppendingString:encodedUser];
             
             NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:requestUrl]];
+            [request setTimeoutInterval:self.connectionTimeout];
             
             [self addFeatureRequestHeaders:request];
             
@@ -99,6 +100,7 @@ static NSString * const kEventRequestCompletedNotification = @"event_request_com
             NSString *requestUrl = [eventsUrl stringByAppendingString:kEventUrl];
             
             NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:requestUrl]];
+            [request setTimeoutInterval:self.connectionTimeout];
             [self addEventRequestHeaders:request];
             
             NSError *error;


### PR DESCRIPTION
We noticed that the connection timeouts are configurable via `LDConfigBuilder`, but the setting hasn't been propagated to the various HTTP request operations.