### PR TITLE
Allow notification of the client if the server connection to retrieve flags fails.

### DIFF
--- a/Darkly/DarklyConstants.h
+++ b/Darkly/DarklyConstants.h
@@ -38,6 +38,7 @@ extern NSString * const kUserDictionaryStorageKey;
 extern NSString * const kDeviceIdentifierKey;
 extern NSString *const kLDUserUpdatedNotification;
 extern NSString *const kLDFlagConfigChangedNotification;
+extern NSString *const kLDServerConnectionUnavailable;
 extern NSString *const kLDBackgroundFetchInitiated;
 extern int const kCapacity;
 extern int const kConnectionTimeout;

--- a/Darkly/DarklyConstants.m
+++ b/Darkly/DarklyConstants.m
@@ -26,6 +26,7 @@ NSString * const kDeviceIdentifierKey = @"ldDeviceIdentifier";
 NSString * const kLDUserUpdatedNotification = @"Darkly.UserUpdatedNotification";
 NSString * const kLDBackgroundFetchInitiated = @"Darkly.BackgroundFetchInitiated";
 NSString *const kLDFlagConfigChangedNotification = @"Darkly.FlagConfigChangedNotification";
+NSString *const kLDServerConnectionUnavailable = @"Darkly.ServerConnectionUnavailable";
 int const kCapacity = 100;
 int const kConnectionTimeout = 10;
 int const kDefaultFlushInterval = 30;

--- a/Darkly/LDClient.h
+++ b/Darkly/LDClient.h
@@ -14,6 +14,7 @@
 @optional
 -(void)userDidUpdate;
 -(void)featureFlagDidUpdate:(NSString *)key;
+-(void)serverConnectionUnavailable;
 @end
 
 @interface LDClient : NSObject

--- a/Darkly/LDClient.m
+++ b/Darkly/LDClient.m
@@ -29,6 +29,9 @@
                                                  selector:@selector(userUpdated)
                                                      name: kLDUserUpdatedNotification object: nil];
         [[NSNotificationCenter defaultCenter] addObserver: sharedLDClient
+                                                 selector:@selector(serverUnavailable)
+                                                     name:kLDServerConnectionUnavailable object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver: sharedLDClient
                                                  selector:@selector(configFlagUpdated:)
                                                      name:kLDFlagConfigChangedNotification object:nil];
     });
@@ -288,6 +291,13 @@
 -(void)userUpdated {
     if (self.delegate && [self.delegate respondsToSelector:@selector(userDidUpdate)]) {
         [self.delegate userDidUpdate];
+    }
+}
+
+// Notification handler for ClientManager server connection failed
+-(void)serverUnavailable {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(serverConnectionUnavailable)]) {
+        [self.delegate serverConnectionUnavailable];
     }
 }
 

--- a/Darkly/LDClientManager.m
+++ b/Darkly/LDClientManager.m
@@ -199,6 +199,8 @@
         }
     } else {
         DEBUG_LOGX(@"ClientManager processedConfig method called after receiving failure response from server");
+        [[NSNotificationCenter defaultCenter] postNotificationName: kLDServerConnectionUnavailable
+                                                            object: nil];
     }
 }
     


### PR DESCRIPTION
If the connection to retrieve the current flag state fails, clients _may_ want to know about that failure.
This is especially true if the flags provide required information not available at build time.