### PR TITLE
Add additional check to comparison of user config flag values

### DIFF
--- a/Darkly/LDDataManager.m
+++ b/Darkly/LDDataManager.m
@@ -99,7 +99,8 @@ dispatch_queue_t eventsQueue;
 
 - (void)compareConfigForUser:(LDUserModel *)user withNewUser:(LDUserModel *)newUser {
     for (NSString *key in [[newUser.config dictionaryValue] objectForKey:kFeaturesJsonDictionaryKey]) {
-        if(user == nil || ![[newUser.config configFlagValue:key] isEqual:[user.config configFlagValue:key]]) {
+        NSObject *userVal = [user.config configFlagValue:key];
+        if(user == nil || (userVal != nil && ![[newUser.config configFlagValue:key] isEqual:userVal])) {
             [[NSNotificationCenter defaultCenter] postNotificationName:kLDFlagConfigChangedNotification object:nil userInfo:[NSDictionary dictionaryWithObject:key forKey:kFlagKey]];
         }
     }


### PR DESCRIPTION
I came across this issue when starting LaunchDarkly as an anonymous user.

Upon the first installation of the app, the user is signed out and registered as anonymous. The dictionary that is saved to `NSUserDefaults` does not contain any config information as it has not been fetched yet.
```
{
    anonymous = 1;
    key = "63EC2339...";
    ..
}
```

Once the config is fetched, it's saved on the registered user.
```
{
    anonymous = 1;
    config =     {
        "my-custom-flag" = 0;
    };
    key = "63EC2339...";
    ..
}
```

However, the comparison being done in `compareConfigForUser:withNewUser:` does not account for the config not existing at all. So in the scenario above, this comparison `![[newUser.config configFlagValue:key] isEqual:userVal]` will always be true which results in the notification being posted even though the flag did not change.

Adding a check to make sure the `user` config value is not nil before posting the notification solved my use case. But if this is done by design or there is a better way around this, please let me know.