### PR TITLE
Version 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the LaunchDarkly iOS SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.12.0] - 2018-04-30
+### Fixed
+- Calling `updateUser` on LDClient while streaming no longer causes the SDK to request feature flags. The SDK now disconnects from the `clientstream` and reconnects with the updated user.
+- Calling `updateUser` on LDClient while polling now resets the polling timer after making a feature flag request.
+
 ## [2.11.2] - 2018-04-06
 ### Changed
 - Changes the minimum required `DarklyEventSource` to version `3.2.1` in the CocoaPods podspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the LaunchDarkly iOS SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
-## [2.12.0] - 2018-04-20
+## [2.12.0] - 2018-04-22
 ### Added
 - `LDClient` `isOnline` readonly property that reports the online/offline status.
 - `LDClient` `setOnline` method to set the online/offline status. `setOnline` may operate asynchronously, so the client calls an optional completion block when the requested operation completes.
@@ -11,7 +11,7 @@ All notable changes to the LaunchDarkly iOS SDK will be documented in this file.
 - Fixed potential memory leak with `DarklyEventSource`.
 
 ### Removed
-- `LDClient` `online` & `offline` methods.
+- `LDClient` `online` and `offline` methods.
 
 ### Fixed
 - Calling `updateUser` on `LDClient` while streaming no longer causes the SDK to request feature flags. The SDK now disconnects from the LaunchDarkly service and reconnects with the updated user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 All notable changes to the LaunchDarkly iOS SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
-## [2.12.0] - 2018-04-30
+## [2.12.0] - 2018-04-20
+### Added
+- `LDClient` `isOnline` readonly property that reports the online/offline status.
+- `LDClient` `setOnline` method to set the online/offline status. `setOnline` may operate asynchronously, so the client calls an optional completion block when the requested operation completes.
+
+### Changed
+- Fixed potential memory leak with `DarklyEventSource`.
+
+### Removed
+- `LDClient` `online` & `offline` methods.
+
 ### Fixed
-- Calling `updateUser` on LDClient while streaming no longer causes the SDK to request feature flags. The SDK now disconnects from the `clientstream` and reconnects with the updated user.
-- Calling `updateUser` on LDClient while polling now resets the polling timer after making a feature flag request.
+- Calling `updateUser` on `LDClient` while streaming no longer causes the SDK to request feature flags. The SDK now disconnects from the LaunchDarkly service and reconnects with the updated user.
+- Calling `updateUser` on `LDClient` while polling now resets the polling timer after making a feature flag request.
 
 ## [2.11.2] - 2018-04-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly iOS SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.11.2] - 2018-04-06
+### Changed
+- Changes the minimum required `DarklyEventSource` to version `3.2.1` in the CocoaPods podspec
+
 ## [2.11.1] - 2018-03-26
 ### Changed
 - Changes the minimum required `DarklyEventSource` to version `3.2.0` in the CocoaPods podspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the LaunchDarkly iOS SDK will be documented in this file.
 ## [2.11.2] - 2018-04-06
 ### Changed
 - Changes the minimum required `DarklyEventSource` to version `3.2.1` in the CocoaPods podspec
+- The maximum backoff time for reconnecting to the feature stream is now 1 hour.
 
 ## [2.11.1] - 2018-03-26
 ### Changed

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "launchdarkly/ios-eventsource" >= 3.2.1
+github "launchdarkly/ios-eventsource" >= 3.2.3

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "launchdarkly/ios-eventsource" >= 3.2
+github "launchdarkly/ios-eventsource" >= 3.2.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "launchdarkly/ios-eventsource" "3.2.1"
+github "launchdarkly/ios-eventsource" "3.2.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "launchdarkly/ios-eventsource" "3.2.0"
+github "launchdarkly/ios-eventsource" "3.2.1"

--- a/Darkly.xcodeproj/project.pbxproj
+++ b/Darkly.xcodeproj/project.pbxproj
@@ -162,6 +162,16 @@
 		8305EC8A202243D6002F20DB /* nullConfigIsANull-null-withVersion.json in Resources */ = {isa = PBXBuildFile; fileRef = 8305EC89202243D6002F20DB /* nullConfigIsANull-null-withVersion.json */; };
 		8305EC8C2022440D002F20DB /* nullConfigIsANull-null-withoutVersion.json in Resources */ = {isa = PBXBuildFile; fileRef = 8305EC8B2022440D002F20DB /* nullConfigIsANull-null-withoutVersion.json */; };
 		8305EC8E20227365002F20DB /* featureFlags-withoutVersions.json in Resources */ = {isa = PBXBuildFile; fileRef = 8305EC8D20227365002F20DB /* featureFlags-withoutVersions.json */; };
+		830C2AC5207579AC001D645D /* LDThrottler.h in Headers */ = {isa = PBXBuildFile; fileRef = 830C2AC3207579AC001D645D /* LDThrottler.h */; };
+		830C2AC6207579AC001D645D /* LDThrottler.h in Headers */ = {isa = PBXBuildFile; fileRef = 830C2AC3207579AC001D645D /* LDThrottler.h */; };
+		830C2AC7207579AC001D645D /* LDThrottler.h in Headers */ = {isa = PBXBuildFile; fileRef = 830C2AC3207579AC001D645D /* LDThrottler.h */; };
+		830C2AC8207579AC001D645D /* LDThrottler.h in Headers */ = {isa = PBXBuildFile; fileRef = 830C2AC3207579AC001D645D /* LDThrottler.h */; };
+		830C2AC9207579AC001D645D /* LDThrottler.m in Sources */ = {isa = PBXBuildFile; fileRef = 830C2AC4207579AC001D645D /* LDThrottler.m */; };
+		830C2ACA207579AC001D645D /* LDThrottler.m in Sources */ = {isa = PBXBuildFile; fileRef = 830C2AC4207579AC001D645D /* LDThrottler.m */; };
+		830C2ACB207579AC001D645D /* LDThrottler.m in Sources */ = {isa = PBXBuildFile; fileRef = 830C2AC4207579AC001D645D /* LDThrottler.m */; };
+		830C2ACC207579AC001D645D /* LDThrottler.m in Sources */ = {isa = PBXBuildFile; fileRef = 830C2AC4207579AC001D645D /* LDThrottler.m */; };
+		830C2ACF20757CE9001D645D /* LDThrottlerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 830C2ACE20757CE9001D645D /* LDThrottlerTest.m */; };
+		830C2AD220768697001D645D /* LDThrottler+Testable.m in Sources */ = {isa = PBXBuildFile; fileRef = 830C2AD120768697001D645D /* LDThrottler+Testable.m */; };
 		83258A3D1F323049008C2133 /* LDClientManager+EventSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 83258A3C1F323049008C2133 /* LDClientManager+EventSource.m */; };
 		83258A401F3244D0008C2133 /* LDUserBuilder+Testable.m in Sources */ = {isa = PBXBuildFile; fileRef = 83258A3F1F3244D0008C2133 /* LDUserBuilder+Testable.m */; };
 		83258A421F32721A008C2133 /* emptyConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = 83258A411F32721A008C2133 /* emptyConfig.json */; };
@@ -368,6 +378,11 @@
 		8305EC8D20227365002F20DB /* featureFlags-withoutVersions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "featureFlags-withoutVersions.json"; sourceTree = "<group>"; };
 		830BF92F202A8854006DF9B1 /* NSJSONSerialization+Testable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSJSONSerialization+Testable.h"; sourceTree = "<group>"; };
 		830BF930202A8855006DF9B1 /* NSJSONSerialization+Testable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSJSONSerialization+Testable.m"; sourceTree = "<group>"; };
+		830C2AC3207579AC001D645D /* LDThrottler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LDThrottler.h; sourceTree = "<group>"; };
+		830C2AC4207579AC001D645D /* LDThrottler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LDThrottler.m; sourceTree = "<group>"; };
+		830C2ACE20757CE9001D645D /* LDThrottlerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LDThrottlerTest.m; sourceTree = "<group>"; };
+		830C2AD020768697001D645D /* LDThrottler+Testable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LDThrottler+Testable.h"; sourceTree = "<group>"; };
+		830C2AD120768697001D645D /* LDThrottler+Testable.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "LDThrottler+Testable.m"; sourceTree = "<group>"; };
 		83258A3B1F323049008C2133 /* LDClientManager+EventSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LDClientManager+EventSource.h"; sourceTree = "<group>"; };
 		83258A3C1F323049008C2133 /* LDClientManager+EventSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "LDClientManager+EventSource.m"; sourceTree = "<group>"; };
 		83258A3E1F3244D0008C2133 /* LDUserBuilder+Testable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LDUserBuilder+Testable.h"; sourceTree = "<group>"; };
@@ -589,6 +604,8 @@
 				690346E61E68990000E45133 /* LDPollingManager.m */,
 				690346E71E68990000E45133 /* LDRequestManager.h */,
 				690346E81E68990000E45133 /* LDRequestManager.m */,
+				830C2AC3207579AC001D645D /* LDThrottler.h */,
+				830C2AC4207579AC001D645D /* LDThrottler.m */,
 				690346E91E68990000E45133 /* LDUserBuilder.h */,
 				690346EA1E68990000E45133 /* LDUserBuilder.m */,
 				690346EB1E68990000E45133 /* LDUserModel.h */,
@@ -614,6 +631,7 @@
 				6903471B1E689B9F00E45133 /* LDUtilTest.m */,
 				6903471C1E689B9F00E45133 /* LDClientManagerTest.m */,
 				6903471F1E689B9F00E45133 /* LDConfigTest.m */,
+				830C2ACE20757CE9001D645D /* LDThrottlerTest.m */,
 				690347201E689B9F00E45133 /* DarklyXCTestCase.h */,
 				690347221E689B9F00E45133 /* DarklyXCTestCase.m */,
 				690346CE1E6872EA00E45133 /* Info.plist */,
@@ -726,6 +744,8 @@
 				83EF678C1F98FC9200403126 /* LDFlagConfigModel+Testable.m */,
 				830BF92F202A8854006DF9B1 /* NSJSONSerialization+Testable.h */,
 				830BF930202A8855006DF9B1 /* NSJSONSerialization+Testable.m */,
+				830C2AD020768697001D645D /* LDThrottler+Testable.h */,
+				830C2AD120768697001D645D /* LDThrottler+Testable.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -791,6 +811,7 @@
 				6903470D1E68990000E45133 /* NSDictionary+JSON.h in Headers */,
 				690347091E68990000E45133 /* LDUtil.h in Headers */,
 				69BAF40D1E9AAB4800747613 /* Darkly.h in Headers */,
+				830C2AC5207579AC001D645D /* LDThrottler.h in Headers */,
 				690346F71E68990000E45133 /* LDClient.h in Headers */,
 				833D08CB1F3B97EB00BEED83 /* NSThread+MainExecutable.h in Headers */,
 				83889B171F8F28AB00A4EF69 /* NSURLResponse+Unauthorized.h in Headers */,
@@ -822,6 +843,7 @@
 				69A87EAA1E74712800B88B23 /* LDUserBuilder.h in Headers */,
 				69A87EAE1E74712800B88B23 /* LDUtil.h in Headers */,
 				69071F801EA2A7CC00497F93 /* Darkly.h in Headers */,
+				830C2AC8207579AC001D645D /* LDThrottler.h in Headers */,
 				69A87E9C1E74712800B88B23 /* LDClient.h in Headers */,
 				833D08CE1F3B97EB00BEED83 /* NSThread+MainExecutable.h in Headers */,
 				83889B1A1F8F28AB00A4EF69 /* NSURLResponse+Unauthorized.h in Headers */,
@@ -853,6 +875,7 @@
 				69BD7E2B1E6C79910056D70F /* LDUserBuilder.h in Headers */,
 				69BD7E2F1E6C79910056D70F /* LDUtil.h in Headers */,
 				69071F7F1EA2A7CB00497F93 /* Darkly.h in Headers */,
+				830C2AC7207579AC001D645D /* LDThrottler.h in Headers */,
 				69BD7E1D1E6C79910056D70F /* LDClient.h in Headers */,
 				833D08CD1F3B97EB00BEED83 /* NSThread+MainExecutable.h in Headers */,
 				83889B191F8F28AB00A4EF69 /* NSURLResponse+Unauthorized.h in Headers */,
@@ -884,6 +907,7 @@
 				69F3F6971E6BF82C00079A09 /* LDClient.h in Headers */,
 				69F3F6AB1E6BF82C00079A09 /* NSDictionary+JSON.h in Headers */,
 				69071F7E1EA2A7CA00497F93 /* Darkly.h in Headers */,
+				830C2AC6207579AC001D645D /* LDThrottler.h in Headers */,
 				69F3F6A31E6BF82C00079A09 /* LDRequestManager.h in Headers */,
 				833D08CC1F3B97EB00BEED83 /* NSThread+MainExecutable.h in Headers */,
 				83889B181F8F28AB00A4EF69 /* NSURLResponse+Unauthorized.h in Headers */,
@@ -1343,6 +1367,7 @@
 				8305EC6B20221973002F20DB /* LDFlagConfigValue.m in Sources */,
 				83EF67851F979B4100403126 /* LDEvent+Unauthorized.m in Sources */,
 				6903470E1E68990000E45133 /* NSDictionary+JSON.m in Sources */,
+				830C2AC9207579AC001D645D /* LDThrottler.m in Sources */,
 				690347021E68990000E45133 /* LDPollingManager.m in Sources */,
 				690346FC1E68990000E45133 /* LDConfig.m in Sources */,
 				690347061E68990000E45133 /* LDUserBuilder.m in Sources */,
@@ -1361,6 +1386,7 @@
 				8349F51E1F19352300B1F3DB /* NSDictionary+StringKey_Matchable.m in Sources */,
 				839956E820053081009707D1 /* LDUserModel+Testable.m in Sources */,
 				690347291E689B9F00E45133 /* LDEventModelTest.m in Sources */,
+				830C2ACF20757CE9001D645D /* LDThrottlerTest.m in Sources */,
 				690347301E689B9F00E45133 /* LDConfigTest.m in Sources */,
 				690347261E689B9F00E45133 /* LDUserBuilderTest.m in Sources */,
 				832C788D1F2977B800E334A2 /* NSString+RemoveWhitespace.m in Sources */,
@@ -1369,6 +1395,7 @@
 				6903472B1E689B9F00E45133 /* LDPollingManagerTest.m in Sources */,
 				83EF67901F99365600403126 /* LDClient+Testable.m in Sources */,
 				83258A3D1F323049008C2133 /* LDClientManager+EventSource.m in Sources */,
+				830C2AD220768697001D645D /* LDThrottler+Testable.m in Sources */,
 				8305EC7A20222B5E002F20DB /* NSObject+LDFlagConfigValueTest.m in Sources */,
 				83BE938C201A797B00DD1ED9 /* NSJSONSerialization+Testable.m in Sources */,
 				6903472E1E689B9F00E45133 /* LDClientManagerTest.m in Sources */,
@@ -1410,6 +1437,7 @@
 				8305EC6E20221973002F20DB /* LDFlagConfigValue.m in Sources */,
 				83EF67881F979B4100403126 /* LDEvent+Unauthorized.m in Sources */,
 				69A87EAF1E74712800B88B23 /* LDUtil.m in Sources */,
+				830C2ACC207579AC001D645D /* LDThrottler.m in Sources */,
 				69A87EA71E74712800B88B23 /* LDPollingManager.m in Sources */,
 				69A87E9F1E74712800B88B23 /* LDClientManager.m in Sources */,
 				69A87EAD1E74712800B88B23 /* LDUserModel.m in Sources */,
@@ -1439,6 +1467,7 @@
 				8305EC6D20221973002F20DB /* LDFlagConfigValue.m in Sources */,
 				83EF67871F979B4100403126 /* LDEvent+Unauthorized.m in Sources */,
 				69BD7E301E6C79910056D70F /* LDUtil.m in Sources */,
+				830C2ACB207579AC001D645D /* LDThrottler.m in Sources */,
 				69BD7E281E6C79910056D70F /* LDPollingManager.m in Sources */,
 				69BD7E201E6C79910056D70F /* LDClientManager.m in Sources */,
 				69BD7E2E1E6C79910056D70F /* LDUserModel.m in Sources */,
@@ -1468,6 +1497,7 @@
 				8305EC6C20221973002F20DB /* LDFlagConfigValue.m in Sources */,
 				83EF67861F979B4100403126 /* LDEvent+Unauthorized.m in Sources */,
 				69F3F6AA1E6BF82C00079A09 /* LDUtil.m in Sources */,
+				830C2ACA207579AC001D645D /* LDThrottler.m in Sources */,
 				69F3F6A21E6BF82C00079A09 /* LDPollingManager.m in Sources */,
 				69F3F69A1E6BF82C00079A09 /* LDClientManager.m in Sources */,
 				69F3F6A81E6BF82C00079A09 /* LDUserModel.m in Sources */,

--- a/Darkly/DarklyConstants.h
+++ b/Darkly/DarklyConstants.h
@@ -57,3 +57,4 @@ extern NSInteger const kHTTPStatusCodeUnauthorized;
 extern NSInteger const kHTTPStatusCodeMethodNotAllowed;
 extern NSInteger const kHTTPStatusCodeNotImplemented;
 extern NSInteger const kErrorCodeUnauthorized;
+extern NSTimeInterval const kMaxThrottlingDelayInterval;

--- a/Darkly/DarklyConstants.m
+++ b/Darkly/DarklyConstants.m
@@ -4,7 +4,7 @@
 
 #import "DarklyConstants.h"
 
-NSString * const kClientVersion = @"2.11.2";
+NSString * const kClientVersion = @"2.12.0";
 NSString * const kBaseUrl = @"https://app.launchdarkly.com";
 NSString * const kEventsUrl = @"https://mobile.launchdarkly.com";
 NSString * const kStreamUrl = @"https://clientstream.launchdarkly.com";

--- a/Darkly/DarklyConstants.m
+++ b/Darkly/DarklyConstants.m
@@ -44,3 +44,4 @@ NSInteger const kHTTPStatusCodeUnauthorized = 401;
 NSInteger const kHTTPStatusCodeMethodNotAllowed = 405;
 NSInteger const kHTTPStatusCodeNotImplemented = 501;
 NSInteger const kErrorCodeUnauthorized = -kHTTPStatusCodeUnauthorized;
+NSTimeInterval const kMaxThrottlingDelayInterval = 600.0;

--- a/Darkly/DarklyConstants.m
+++ b/Darkly/DarklyConstants.m
@@ -4,7 +4,7 @@
 
 #import "DarklyConstants.h"
 
-NSString * const kClientVersion = @"2.11.1";
+NSString * const kClientVersion = @"2.11.2";
 NSString * const kBaseUrl = @"https://app.launchdarkly.com";
 NSString * const kEventsUrl = @"https://mobile.launchdarkly.com";
 NSString * const kStreamUrl = @"https://clientstream.launchdarkly.com";

--- a/Darkly/LDClient.h
+++ b/Darkly/LDClient.h
@@ -20,6 +20,7 @@
 
 @interface LDClient : NSObject
 
+@property (nonatomic, assign, readonly) BOOL isOnline;
 @property(nonatomic, strong, readonly) LDUserModel *ldUser;
 @property(nonatomic, strong, readonly) LDConfig *ldConfig;
 @property (nonatomic, weak) id<ClientDelegate> delegate;
@@ -125,17 +126,18 @@
  */
 - (LDUserBuilder *)currentUserBuilder;
 /**
- * Set the client to offline mode. No events will be synced to server.
+ * Set the client to online/offline mode. When online events will be synced to server. (Default)
  *
- * @return whether offline mode was successfully updated.
+ * @param goOnline    Desired online/offline mode for the client
  */
-- (BOOL)offline;
+- (void)setOnline:(BOOL)goOnline;
 /**
- * Set the client to online mode. Events will be synced to server. (Default)
+ * Set the client to online/offline mode. When online events will be synced to server. (Default)
  *
- * @return whether online mode was successfully updated.
+ * @param goOnline    Desired online/offline mode for the client
+ * @param completion    Completion block called when setOnline completes
  */
-- (BOOL)online;
+- (void)setOnline:(BOOL)goOnline completion:(void(^)(void))completion;
 /**
  * Sync all events to the server. Events are synced to the server on a
  * regular basis, however this will force all stored events from the client

--- a/Darkly/LDClient.m
+++ b/Darkly/LDClient.m
@@ -74,20 +74,18 @@
 
 - (BOOL)updateUser:(LDUserBuilder *)builder {
     DEBUG_LOGX(@"LDClient updateUser method called");
-    if (self.clientStarted) {
-        if (builder) {
-            self.ldUser = [LDUserBuilder compareNewBuilder:builder withUser:self.ldUser];
-            LDClientManager *clientManager = [LDClientManager sharedInstance];
-            [clientManager syncWithServerForConfig];
-            return YES;
-        } else {
-            DEBUG_LOGX(@"LDClient updateUser needs a non-nil LDUserBuilder object");
-            return NO;
-        }
-    } else {
-        DEBUG_LOGX(@"LDClient not started yet!");
+    if (!self.clientStarted) {
+        DEBUG_LOGX(@"LDClient aborted updateUser: client not started");
         return NO;
     }
+    if (!builder) {
+        DEBUG_LOGX(@"LDClient aborted updateUser: LDUserBuilder is nil");
+        return NO;
+    }
+
+    self.ldUser = [LDUserBuilder compareNewBuilder:builder withUser:self.ldUser];
+    [[LDClientManager sharedInstance] updateUser];
+    return YES;
 }
 
 - (LDUserBuilder *)currentUserBuilder {

--- a/Darkly/LDClientManager.h
+++ b/Darkly/LDClientManager.h
@@ -31,6 +31,7 @@
 - (void)processedConfig:(BOOL)success jsonConfigDictionary:(NSDictionary *)jsonConfigDictionary;
 - (void)startPolling;
 - (void)stopPolling;
+- (void)updateUser;
 - (void)willEnterBackground;
 - (void)willEnterForeground;
 - (void)flushEvents;

--- a/Darkly/LDClientManager.m
+++ b/Darkly/LDClientManager.m
@@ -93,6 +93,24 @@ NSString * const kLDClientManagerStreamMethod = @"meval";
     [self flushEvents];
 }
 
+-(void)updateUser {
+    if (!self.isOnline) {
+        DEBUG_LOGX(@"ClientManager updateUser aborted - manager is offline");
+        return;
+    }
+    if (self.eventSource) {
+        [self stopEventSource];
+    }
+    [[LDPollingManager sharedInstance] stopConfigPolling];
+
+    if ([[[LDClient sharedInstance] ldConfig] streaming]) {
+        [self configureEventSource];
+    } else {
+        [self syncWithServerForConfig];
+        [[LDPollingManager sharedInstance] startConfigPolling];
+    }
+}
+
 - (void)willEnterBackground {
     DEBUG_LOGX(@"ClientManager entering background");
     LDPollingManager *pollingMgr = [LDPollingManager sharedInstance];

--- a/Darkly/LDClientManager.m
+++ b/Darkly/LDClientManager.m
@@ -159,11 +159,13 @@ NSString * const kLDClientManagerStreamMethod = @"meval";
 
         eventSource = [self eventSourceForUser:[LDClient sharedInstance].ldUser config:[LDClient sharedInstance].ldConfig httpHeaders:[self httpHeadersForEventSource]];
 
+        __weak typeof(self) weakSelf = self;
         [eventSource onMessage:^(LDEvent *event) {
-            [self handlePingEvent:event];
-            [self handlePutEvent:event];
-            [self handlePatchEvent:event];
-            [self handleDeleteEvent:event];
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            [strongSelf handlePingEvent:event];
+            [strongSelf handlePutEvent:event];
+            [strongSelf handlePatchEvent:event];
+            [strongSelf handleDeleteEvent:event];
         }];
 
         [eventSource onError:^(LDEvent *event) {
@@ -296,6 +298,7 @@ NSString * const kLDClientManagerStreamMethod = @"meval";
 
 - (void)stopEventSource {
     @synchronized (self) {
+        DEBUG_LOGX(@"ClientManager stopping event source.");
         [eventSource close];
         eventSource = nil;
     }

--- a/Darkly/LDThrottler.h
+++ b/Darkly/LDThrottler.h
@@ -1,0 +1,20 @@
+//
+//  LDThrottler.h
+//  Darkly
+//
+//  Created by Mark Pokorny on 4/4/18. +JMJ
+//  Copyright © 2018 LaunchDarkly. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface LDThrottler : NSObject
+@property (nonatomic, assign, readonly) NSTimeInterval maxDelayInterval;
+@property (nonatomic, assign, readonly) NSUInteger runAttempts;
+@property (nonatomic, assign, readonly) NSTimeInterval delayInterval;
+@property (nonatomic, strong, readonly) NSDate * _Nullable timerStartDate;
+@property (nonatomic, strong, readonly) NSTimer * _Nullable delayTimer;
+
+-(nullable instancetype)initWithMaxDelayInterval:(NSTimeInterval)maxDelaySeconds;
+-(void)runThrottled:(void (^_Nonnull)(void))completion;
+@end

--- a/Darkly/LDThrottler.m
+++ b/Darkly/LDThrottler.m
@@ -1,0 +1,102 @@
+//
+//  LDThrottler.m
+//  Darkly
+//
+//  Created by Mark Pokorny on 4/4/18. +JMJ
+//  Copyright © 2018 LaunchDarkly. All rights reserved.
+//
+
+#import "LDThrottler.h"
+#import "DarklyConstants.h"
+#import "LDUtil.h"
+
+const NSTimeInterval minDelayInterval = 1.0;
+
+@interface LDThrottler()
+@property (nonatomic, assign) NSTimeInterval maxDelayInterval;
+@property (nonatomic, assign) NSUInteger runAttempts;
+@property (nonatomic, assign) NSTimeInterval delayInterval;
+@property (nonatomic, strong) NSTimer *delayTimer;
+@property (nonatomic, strong) NSDate *timerStartDate;
+@property (nonatomic, strong) void(^runBlock)(void);
+@property (nonatomic, strong) void(^timerFiredCallback)(void);
+@end
+
+@implementation LDThrottler
+-(instancetype)initWithMaxDelayInterval:(NSTimeInterval)maxDelayInterval {
+    if (!(self = [super init])) { return nil; }
+
+    self.maxDelayInterval = maxDelayInterval > 0 && maxDelayInterval <= kMaxThrottlingDelayInterval ? maxDelayInterval : kMaxThrottlingDelayInterval;
+    DEBUG_LOG(@"Throttler created with max delay: %0.2f", self.maxDelayInterval);
+
+    return self;
+}
+
+-(void)runThrottled:(void (^)(void))runBlock {
+    if (!runBlock) { return; }
+    if (self.delayInterval == self.maxDelayInterval) {
+        self.runAttempts += 1;
+        self.runBlock = runBlock;
+        DEBUG_LOG(@"Throttler delay interval at max. Allowing delay timer to expire. Run Attempts: %ld", (unsigned long)self.runAttempts);
+        return;
+    }
+
+    @synchronized(self) {
+        if (self.delayTimer) {
+            [self.delayTimer invalidate];
+        }
+    }
+    if (self.runAttempts == 0) {
+        DEBUG_LOGX(@"Throttler executing run block on first attempt.");
+        runBlock();
+    } else {
+        self.runBlock = runBlock;
+    }
+
+    self.runAttempts += 1;
+    self.delayInterval = [self delayIntervalForRunAttempts:self.runAttempts];
+    self.delayTimer = [self delayTimerWithDelayInterval:self.delayInterval];
+    if (self.runAttempts > 1) {
+        DEBUG_LOG(@"Throttler throttling run block. Run Attempts: %ld Delay: %0.2f", (unsigned long)self.runAttempts, self.delayInterval);
+    }
+}
+
+-(NSTimeInterval)delayIntervalForRunAttempts:(NSUInteger)runAttempts {
+    if (runAttempts > log2(self.maxDelayInterval)) { return self.maxDelayInterval; }
+    double maxAttempts = log2(DBL_MAX);  //use to prevent overflowing
+    NSTimeInterval exponentialBackoff = runAttempts < maxAttempts ? MIN(self.maxDelayInterval, minDelayInterval * pow(2, runAttempts)) : self.maxDelayInterval; // pow(x,y) returns x^y
+    NSTimeInterval jitterBackoff = arc4random_uniform(exponentialBackoff);    // arc4random_uniform(upperBound) returns a double uniformly randomized between 0.0..<upperBound
+    return exponentialBackoff / 2 + jitterBackoff / 2;  //half of each should yield [2^(runAttempts-1), 2^runAttempts)
+}
+
+-(NSTimer*)delayTimerWithDelayInterval:(NSUInteger)delaySeconds {
+    if (!self.timerStartDate) {
+        self.timerStartDate = [NSDate date];
+    }
+    NSDate *fireDate = [self.timerStartDate dateByAddingTimeInterval:delaySeconds];
+
+    NSTimer *delayTimer = [[NSTimer alloc] initWithFireDate:fireDate interval:0 target:self selector:@selector(timerFired) userInfo:nil repeats:NO];
+    [[NSRunLoop currentRunLoop] addTimer:delayTimer forMode:NSDefaultRunLoopMode];
+    return delayTimer;
+}
+
+-(void)timerFired {
+    @synchronized(self) {
+        if (self.runAttempts > 1 && self.runBlock) {
+            DEBUG_LOGX(@"Throttler delay timer fired, executing run block.");
+            self.runBlock();
+        }
+
+        self.runAttempts = 0;
+        self.delayInterval = 0.0;
+        self.timerStartDate = nil;
+        self.delayTimer = nil;
+        self.runBlock = nil;
+
+        if (!self.timerFiredCallback) { return; }
+        self.timerFiredCallback();
+        self.timerFiredCallback = nil;
+    }
+}
+
+@end

--- a/DarklyTests/Categories/LDClient+Testable.h
+++ b/DarklyTests/Categories/LDClient+Testable.h
@@ -7,7 +7,9 @@
 //
 
 #import <Darkly/Darkly.h>
+#import "LDThrottler.h"
 
 @interface LDClient(Testable)
 @property (nonatomic, assign) BOOL clientStarted;
+@property (nonatomic, strong) LDThrottler *throttler;
 @end

--- a/DarklyTests/Categories/LDClient+Testable.m
+++ b/DarklyTests/Categories/LDClient+Testable.m
@@ -10,4 +10,5 @@
 
 @implementation LDClient(Testable)
 @dynamic clientStarted;
+@dynamic throttler;
 @end

--- a/DarklyTests/Categories/LDThrottler+Testable.h
+++ b/DarklyTests/Categories/LDThrottler+Testable.h
@@ -1,0 +1,13 @@
+//
+//  LDThrottler+Testable.h
+//  DarklyTests
+//
+//  Created by Mark Pokorny on 4/5/18. +JMJ
+//  Copyright © 2018 LaunchDarkly. All rights reserved.
+//
+
+#import "LDThrottler.h"
+
+@interface LDThrottler(Testable)
+@property (nonatomic, strong) void(^timerFiredCallback)(void);
+@end

--- a/DarklyTests/Categories/LDThrottler+Testable.m
+++ b/DarklyTests/Categories/LDThrottler+Testable.m
@@ -1,0 +1,13 @@
+//
+//  LDThrottler+Testable.m
+//  DarklyTests
+//
+//  Created by Mark Pokorny on 4/5/18. +JMJ
+//  Copyright © 2018 LaunchDarkly. All rights reserved.
+//
+
+#import "LDThrottler+Testable.h"
+
+@implementation LDThrottler(Testable)
+@dynamic timerFiredCallback;
+@end

--- a/DarklyTests/LDClientTest.m
+++ b/DarklyTests/LDClientTest.m
@@ -13,6 +13,7 @@
 #import "LDUserBuilder+Testable.h"
 #import "LDClient+Testable.h"
 #import "NSJSONSerialization+Testable.h"
+#import "LDThrottler.h"
 
 #import "OCMock.h"
 #import <OHHTTPStubs/OHHTTPStubs.h>
@@ -63,6 +64,7 @@ extern NSString * _Nonnull  const kLDFlagConfigJsonDictionaryKeyValue;
 @property (nonatomic, strong) id mockLDClientManager;
 @property (nonatomic, strong) id mockLDDataManager;
 @property (nonatomic, strong) id mockLDRequestManager;
+@property (nonatomic, strong) id throttlerMock;
 @end
 
 NSString *const kFallbackString = @"fallbackString";
@@ -87,6 +89,10 @@ NSString *const kTestMobileKey = @"testMobileKey";
     id mockRequestManager = OCMClassMock([LDRequestManager class]);
     OCMStub(ClassMethod([mockRequestManager sharedInstance])).andReturn(mockRequestManager);
     self.mockLDRequestManager = mockRequestManager;
+
+    self.throttlerMock = OCMClassMock([LDThrottler class]);
+    OCMStub([self.throttlerMock runThrottled:[OCMArg invokeBlock]]);
+    [LDClient sharedInstance].throttler = self.throttlerMock;
 }
 
 - (void)tearDown {
@@ -492,31 +498,64 @@ NSString *const kTestMobileKey = @"testMobileKey";
     OCMVerify([self.dataManagerMock createCustomEvent:@"test" withCustomValuesDictionary:customData user:[OCMArg isKindOfClass:[LDUserModel class]] config:config]);
 }
 
-- (void)testOfflineWithoutStart {
-    XCTAssertFalse([[LDClient sharedInstance] offline]);
+- (void)testSetOnline_NO_beforeStart {
+    [[self.mockLDClientManager reject] setOnline:[OCMArg any]];
+    __block NSInteger completionCallCount = 0;
+
+    [[LDClient sharedInstance] setOnline:NO completion: ^{
+        completionCallCount += 1;
+    }];
+
+    XCTAssertFalse([LDClient sharedInstance].isOnline);
+    [self.mockLDClientManager verify];
+    XCTAssertEqual(completionCallCount, 1);
 }
 
-- (void)testOfflineWithStart {
-    [[self.mockLDClientManager expect] setOnline:YES];
-
+- (void)testSetOnline_NO_afterStart {
     LDConfig *config = [[LDConfig alloc] initWithMobileKey:kTestMobileKey];
     [[LDClient sharedInstance] start:config withUserBuilder:nil];
-    XCTAssertTrue([[LDClient sharedInstance] offline]);
+    [[self.throttlerMock reject] runThrottled:[OCMArg any]];
+    [[self.mockLDClientManager expect] setOnline:NO];
+    __block NSInteger completionCallCount = 0;
+
+    [[LDClient sharedInstance] setOnline:NO completion: ^{
+        completionCallCount += 1;
+    }];
+
+    XCTAssertFalse([LDClient sharedInstance].isOnline);
     [self.mockLDClientManager verify];
+    [self.throttlerMock verify];
+    XCTAssertEqual(completionCallCount, 1);
 }
 
-- (void)testOnlineWithoutStart {
-    XCTAssertFalse([[LDClient sharedInstance] online]);
+- (void)testSetOnline_YES_beforeStart {
+    [[self.mockLDClientManager reject] setOnline:[OCMArg any]];
+    __block NSInteger completionCallCount = 0;
+
+    [[LDClient sharedInstance] setOnline:YES completion: ^{
+        completionCallCount += 1;
+    }];
+
+    XCTAssertFalse([LDClient sharedInstance].isOnline);
+    [self.mockLDClientManager verify];
+    XCTAssertEqual(completionCallCount, 1);
 }
 
-- (void)testOnlineWithStart {
+- (void)testSetOnline_YES_afterStart {
     LDConfig *config = [[LDConfig alloc] initWithMobileKey:kTestMobileKey];
-    [[LDClient sharedInstance] start:config withUserBuilder:nil];   //sets LDClientManager online...start the mock after calling start
-
+    [[LDClient sharedInstance] start:config withUserBuilder:nil];
+    [[LDClient sharedInstance] setOnline:NO];
     [[self.mockLDClientManager expect] setOnline:YES];
+    __block NSInteger completionCallCount = 0;
+    //The throttler mock expectation is not getting fulfilled even though the LDClient does invoke it.
+    //Since the throttler mock is set to execute blocks, setting the expectation on the client manager mock verifies that the client is calling the throttler
 
-    XCTAssertTrue([[LDClient sharedInstance] online]);
+    [[LDClient sharedInstance] setOnline:YES completion: ^{
+        completionCallCount += 1;
+    }];
+
     [self.mockLDClientManager verify];
+    XCTAssertEqual(completionCallCount, 1);
 }
 
 - (void)testFlushWithoutStart {

--- a/DarklyTests/LDThrottlerTest.m
+++ b/DarklyTests/LDThrottlerTest.m
@@ -1,0 +1,165 @@
+//
+//  LDThrottlerTest.m
+//  DarklyTests
+//
+//  Created by Mark Pokorny on 4/4/18. +JMJ
+//  Copyright © 2018 LaunchDarkly. All rights reserved.
+//
+
+#import "DarklyXCTestCase.h"
+#import "DarklyConstants.h"
+#import "LDThrottler.h"
+#import "LDThrottler+Testable.h"
+
+@interface LDThrottlerTest: DarklyXCTestCase
+
+@end
+
+const NSTimeInterval delayInterval = 10.0;
+
+@implementation LDThrottlerTest
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+-(void)testInitWithMaxDelaySeconds {
+    LDThrottler *throttler = [[LDThrottler alloc] initWithMaxDelayInterval:delayInterval];
+    XCTAssertTrue(throttler.maxDelayInterval == delayInterval);
+    XCTAssertTrue(throttler.runAttempts == 0);
+    XCTAssertTrue(throttler.delayInterval == 0);
+    XCTAssertNil(throttler.delayTimer);
+}
+
+-(void)testInitWithMaxDelaySecondsTooLong {
+    LDThrottler *throttler = [[LDThrottler alloc] initWithMaxDelayInterval:kMaxThrottlingDelayInterval + 1.0];
+    XCTAssertTrue(throttler.maxDelayInterval == kMaxThrottlingDelayInterval);
+    XCTAssertTrue(throttler.runAttempts == 0);
+    XCTAssertTrue(throttler.delayInterval == 0);
+    XCTAssertNil(throttler.delayTimer);
+}
+
+-(void)testInitWithMaxDelaySecondsTooShort {
+    LDThrottler *throttler = [[LDThrottler alloc] initWithMaxDelayInterval:0];
+    XCTAssertTrue(throttler.maxDelayInterval == kMaxThrottlingDelayInterval);
+    XCTAssertTrue(throttler.runAttempts == 0);
+    XCTAssertTrue(throttler.delayInterval == 0);
+    XCTAssertNil(throttler.delayTimer);
+}
+
+-(void)testRunThrottledFirstTry {
+    LDThrottler *throttler = [[LDThrottler alloc] initWithMaxDelayInterval:delayInterval];
+    XCTestExpectation *timerFiredCalledExpectation = [self expectationWithDescription:@"Timer fired called expectation"];
+    throttler.timerFiredCallback = ^{
+        [timerFiredCalledExpectation fulfill];
+    };
+    __block NSInteger completionBlockCallCount = 0;
+    __block NSDate *completionBlockCallDate;
+    NSDate *runThrottledStartDate = [NSDate date];
+
+    [throttler runThrottled:^{
+        completionBlockCallCount += 1;
+        completionBlockCallDate = [NSDate date];
+    }];
+
+    [self waitForExpectations:@[timerFiredCalledExpectation] timeout:2.0];
+
+    XCTAssertTrue(completionBlockCallCount == 1);
+    XCTAssertNotNil(completionBlockCallDate);
+    if (completionBlockCallDate) {
+        NSTimeInterval delayTime = [completionBlockCallDate timeIntervalSinceDate:runThrottledStartDate];
+        XCTAssertTrue(delayTime < 0.1);
+    }
+    XCTAssertTrue(throttler.runAttempts == 0);
+    XCTAssertTrue(throttler.delayInterval == 0);
+    XCTAssertNil(throttler.timerStartDate);
+    XCTAssertNil(throttler.delayTimer);
+}
+
+-(void)testRunThrottledSecondTry {
+    LDThrottler *throttler = [[LDThrottler alloc] initWithMaxDelayInterval:delayInterval];
+    XCTestExpectation *timerFiredCalledExpectation = [self expectationWithDescription:@"Timer fired called expectation"];
+    throttler.timerFiredCallback = ^{
+        [timerFiredCalledExpectation fulfill];
+    };
+    __block NSInteger completionBlockCallCount = 0;
+    __block NSMutableArray<NSDate*> *completionBlockCallDates = [NSMutableArray arrayWithCapacity:2];
+    NSDate *runThrottledStartDate = [NSDate date];
+
+    for (NSUInteger attempt = 0; attempt < 2; attempt++) {
+        [throttler runThrottled:^{
+            completionBlockCallCount += 1;
+            [completionBlockCallDates addObject:[NSDate date]];
+        }];
+    }
+
+    [self waitForExpectations:@[timerFiredCalledExpectation] timeout:4.0];
+
+    XCTAssertTrue(completionBlockCallCount == 2);
+    XCTAssertTrue(completionBlockCallDates.count == 2);
+    if (completionBlockCallDates.count == 2) {
+        NSTimeInterval delayTime = [completionBlockCallDates[0] timeIntervalSinceDate:runThrottledStartDate];
+        XCTAssertTrue(delayTime < 0.1);
+        delayTime = [completionBlockCallDates[1] timeIntervalSinceDate:completionBlockCallDates[0]];
+        XCTAssertTrue(delayTime < 4.0);
+    }
+    XCTAssertTrue(throttler.runAttempts == 0);
+    XCTAssertTrue(throttler.delayInterval == 0);
+    XCTAssertNil(throttler.timerStartDate);
+    XCTAssertNil(throttler.delayTimer);
+}
+
+-(void)testRunThrottledMultipleTries {
+    LDThrottler *throttler = [[LDThrottler alloc] initWithMaxDelayInterval:delayInterval];
+    NSUInteger runAttempts = ceil(log2(delayInterval));
+
+    __block NSInteger completionBlockCallCount = 0;
+    NSDate *timerStartDate;
+    for (NSUInteger attempt = 0; attempt < runAttempts; attempt++) {
+        NSTimeInterval delayIntervalForPreviousAttempt = throttler.delayInterval;
+        [throttler runThrottled:^{
+            completionBlockCallCount += 1;
+        }];
+        if (attempt == 0) {
+            timerStartDate = throttler.timerStartDate;
+        }
+        XCTAssertTrue(delayIntervalForPreviousAttempt < throttler.delayInterval);
+        XCTAssertEqual(timerStartDate, throttler.timerStartDate);
+        XCTAssertNotNil(throttler.delayTimer);
+    }
+    //Didn't wait for the delay timer to fire,
+    XCTAssertTrue(completionBlockCallCount == 1);
+    XCTAssertTrue(throttler.runAttempts == runAttempts);
+}
+
+-(void)testRunThrottledMaxDelay {
+    LDThrottler *throttler = [[LDThrottler alloc] initWithMaxDelayInterval:delayInterval];
+    __block NSInteger completionBlockCallCount = 0;
+    NSDate *timerStartDate;
+    NSUInteger runAttempts = ceil(log2(delayInterval)) + 1;
+
+    for (NSUInteger attempt = 0; attempt < runAttempts; attempt++) {
+        NSTimeInterval delayIntervalForPreviousAttempt = throttler.delayInterval;
+        [throttler runThrottled:^{
+            completionBlockCallCount += 1;
+        }];
+        if (attempt == 0) {
+            timerStartDate = throttler.timerStartDate;
+        }
+        XCTAssertTrue(delayIntervalForPreviousAttempt < throttler.delayInterval || throttler.delayInterval == delayInterval);
+        XCTAssertEqual(timerStartDate, throttler.timerStartDate);
+        XCTAssertNotNil(throttler.delayTimer);
+    }
+
+    //Didn't wait for the delay timer to fire,
+    XCTAssertTrue(completionBlockCallCount == 1);
+    XCTAssertTrue(throttler.runAttempts == runAttempts);
+    XCTAssertTrue(throttler.delayInterval == delayInterval);
+}
+
+@end

--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -30,6 +30,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.subspec 'Core' do |eventSource|
-    eventSource.dependency 'DarklyEventSource', '~>3.2.0'
+    eventSource.dependency 'DarklyEventSource', '~>3.2.3'
   end
 end

--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "LaunchDarkly"
-  s.version      = "2.11.1"
+  s.version      = "2.11.2"
   s.summary      = "iOS SDK for LaunchDarkly"
 
   s.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = "9.0"
   s.osx.deployment_target     = '10.10'
 
-  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "2.11.1" }
+  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "2.11.2" }
 
   s.source_files  = "Darkly/*.{h,m}"
 

--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "LaunchDarkly"
-  s.version      = "2.11.2"
+  s.version      = "2.12.0"
   s.summary      = "iOS SDK for LaunchDarkly"
 
   s.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = "9.0"
   s.osx.deployment_target     = '10.10'
 
-  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "2.11.2" }
+  s.source       = { :git => "https://github.com/launchdarkly/ios-client.git", :tag => "2.12.0" }
 
   s.source_files  = "Darkly/*.{h,m}"
 

--- a/Podfile
+++ b/Podfile
@@ -1,22 +1,22 @@
 use_frameworks!
 target 'Darkly_iOS' do
     platform :ios, '8.0'
-    pod 'DarklyEventSource', '~> 3.2'
+    pod 'DarklyEventSource', '~> 3.2.1'
 end
 
 target 'Darkly_tvOS' do
     platform :tvos, '9.0'
-    pod 'DarklyEventSource', '~> 3.2'
+    pod 'DarklyEventSource', '~> 3.2.1'
 end
 
 target 'Darkly_watchOS' do
     platform :watchos, '2.0'
-    pod 'DarklyEventSource', '~> 3.2'
+    pod 'DarklyEventSource', '~> 3.2.1'
 end
 
 target 'Darkly_osx' do
     platform :osx, '10.10'
-    pod 'DarklyEventSource', '~> 3.2'
+    pod 'DarklyEventSource', '~> 3.2.1'
 end
 
 target 'DarklyTests' do

--- a/Podfile
+++ b/Podfile
@@ -1,22 +1,22 @@
 use_frameworks!
 target 'Darkly_iOS' do
     platform :ios, '8.0'
-    pod 'DarklyEventSource', '~> 3.2.1'
+    pod 'DarklyEventSource', '~> 3.2.3'
 end
 
 target 'Darkly_tvOS' do
     platform :tvos, '9.0'
-    pod 'DarklyEventSource', '~> 3.2.1'
+    pod 'DarklyEventSource', '~> 3.2.3'
 end
 
 target 'Darkly_watchOS' do
     platform :watchos, '2.0'
-    pod 'DarklyEventSource', '~> 3.2.1'
+    pod 'DarklyEventSource', '~> 3.2.3'
 end
 
 target 'Darkly_osx' do
     platform :osx, '10.10'
-    pod 'DarklyEventSource', '~> 3.2.1'
+    pod 'DarklyEventSource', '~> 3.2.3'
 end
 
 target 'DarklyTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - DarklyEventSource (3.2.0)
+  - DarklyEventSource (3.2.1)
   - OCMock (3.4.1)
   - OHHTTPStubs (4.8.0):
     - OHHTTPStubs/Default (= 4.8.0)
@@ -16,15 +16,15 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (4.8.0)
 
 DEPENDENCIES:
-  - DarklyEventSource (~> 3.2)
+  - DarklyEventSource (~> 3.2.1)
   - OCMock (~> 3.1)
   - OHHTTPStubs (~> 4.2)
 
 SPEC CHECKSUMS:
-  DarklyEventSource: ad6a75c82b22bea91c75fc980a563f6d2902ce90
+  DarklyEventSource: 9dcacedde9c1d88b3d8bc02e8dd201d3c8e3a9d9
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: b393565822317305b87a1440d4c7aff131679f66
 
-PODFILE CHECKSUM: f3f36ff2533f4e1230e409cec137989205971a1f
+PODFILE CHECKSUM: 38ef5f5884765c22b8d800b851a976de2d7d3818
 
 COCOAPODS: 1.4.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - DarklyEventSource (3.2.1)
+  - DarklyEventSource (3.2.3)
   - OCMock (3.4.1)
   - OHHTTPStubs (4.8.0):
     - OHHTTPStubs/Default (= 4.8.0)
@@ -16,15 +16,15 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (4.8.0)
 
 DEPENDENCIES:
-  - DarklyEventSource (~> 3.2.1)
+  - DarklyEventSource (~> 3.2.3)
   - OCMock (~> 3.1)
   - OHHTTPStubs (~> 4.2)
 
 SPEC CHECKSUMS:
-  DarklyEventSource: 9dcacedde9c1d88b3d8bc02e8dd201d3c8e3a9d9
+  DarklyEventSource: d5c8e000988ee1feac6c3ffa3dcbdfbaca10d444
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: b393565822317305b87a1440d4c7aff131679f66
 
-PODFILE CHECKSUM: 38ef5f5884765c22b8d800b851a976de2d7d3818
+PODFILE CHECKSUM: 09df0b8e563d60585362751cc2450fe49d915cc9
 
 COCOAPODS: 1.4.0

--- a/Pods/DarklyEventSource/LDEventSource/LDEventSource.m
+++ b/Pods/DarklyEventSource/LDEventSource/LDEventSource.m
@@ -11,7 +11,7 @@
 
 static CGFloat const ES_RETRY_INTERVAL = 1.0;
 static CGFloat const ES_DEFAULT_TIMEOUT = 300.0;
-static CGFloat const ES_MAX_RECONNECT_TIME = 180.0;
+static CGFloat const ES_MAX_RECONNECT_TIME = 3600.0;
 
 static NSString *const ESKeyValueDelimiter = @":";
 static NSString *const LDEventSeparatorLFLF = @"\n\n";

--- a/Pods/DarklyEventSource/LDEventSource/LDEventSource.m
+++ b/Pods/DarklyEventSource/LDEventSource/LDEventSource.m
@@ -93,8 +93,9 @@ static NSInteger const HTTPStatusCodeUnauthorized = 401;
         connectionQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
         
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(_retryInterval * NSEC_PER_SEC));
+        __weak typeof(self) weakSelf = self;
         dispatch_after(popTime, connectionQueue, ^(void){
-            [self _open];
+            [weakSelf _open];
         });
     }
     return self;
@@ -134,6 +135,7 @@ static NSInteger const HTTPStatusCodeUnauthorized = 401;
     wasClosed = YES;
     [self.eventSourceTask cancel];
     [self.session finishTasksAndInvalidate];
+    [self.listeners removeAllObjects];
 }
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask
@@ -169,8 +171,9 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
         }
         
         if (!line || line.length == 0) {
+            __weak typeof(self) weakSelf = self;
             dispatch_async(messageQueue, ^{
-                [self _dispatchEvent:event];
+                [weakSelf _dispatchEvent:event];
             });
             
             event = [LDEvent new];
@@ -224,8 +227,9 @@ didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSe
     
     if (![self responseIsUnauthorizedForTask:task]) {
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)([self increaseIntervalWithBackoff] * NSEC_PER_SEC));
+        __weak typeof(self) weakSelf = self;
         dispatch_after(popTime, connectionQueue, ^(void){
-            [self _open];
+            [weakSelf _open];
         });
     }
 }

--- a/Pods/DarklyEventSource/README.md
+++ b/Pods/DarklyEventSource/README.md
@@ -93,7 +93,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource'
+pod 'DarklyEventSource', '~> 3.2.1'
 end
 ```
 

--- a/Pods/DarklyEventSource/README.md
+++ b/Pods/DarklyEventSource/README.md
@@ -93,7 +93,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
 target 'TargetName' do
-pod 'DarklyEventSource', '~> 3.2.1'
+pod 'DarklyEventSource', '~> 3.2.3'
 end
 ```
 
@@ -117,7 +117,7 @@ $ brew install carthage
 To integrate EventSource into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "launchdarkly/ios-eventsource"
+github "launchdarkly/ios-eventsource" >= 3.2.3
 ```
 
 Run `carthage` to build the framework and drag the built `EventSource.framework` into your Xcode project.

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - DarklyEventSource (3.2.0)
+  - DarklyEventSource (3.2.1)
   - OCMock (3.4.1)
   - OHHTTPStubs (4.8.0):
     - OHHTTPStubs/Default (= 4.8.0)
@@ -16,15 +16,15 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (4.8.0)
 
 DEPENDENCIES:
-  - DarklyEventSource (~> 3.2)
+  - DarklyEventSource (~> 3.2.1)
   - OCMock (~> 3.1)
   - OHHTTPStubs (~> 4.2)
 
 SPEC CHECKSUMS:
-  DarklyEventSource: ad6a75c82b22bea91c75fc980a563f6d2902ce90
+  DarklyEventSource: 9dcacedde9c1d88b3d8bc02e8dd201d3c8e3a9d9
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: b393565822317305b87a1440d4c7aff131679f66
 
-PODFILE CHECKSUM: f3f36ff2533f4e1230e409cec137989205971a1f
+PODFILE CHECKSUM: 38ef5f5884765c22b8d800b851a976de2d7d3818
 
 COCOAPODS: 1.4.0

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - DarklyEventSource (3.2.1)
+  - DarklyEventSource (3.2.3)
   - OCMock (3.4.1)
   - OHHTTPStubs (4.8.0):
     - OHHTTPStubs/Default (= 4.8.0)
@@ -16,15 +16,15 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (4.8.0)
 
 DEPENDENCIES:
-  - DarklyEventSource (~> 3.2.1)
+  - DarklyEventSource (~> 3.2.3)
   - OCMock (~> 3.1)
   - OHHTTPStubs (~> 4.2)
 
 SPEC CHECKSUMS:
-  DarklyEventSource: 9dcacedde9c1d88b3d8bc02e8dd201d3c8e3a9d9
+  DarklyEventSource: d5c8e000988ee1feac6c3ffa3dcbdfbaca10d444
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: b393565822317305b87a1440d4c7aff131679f66
 
-PODFILE CHECKSUM: 38ef5f5884765c22b8d800b851a976de2d7d3818
+PODFILE CHECKSUM: 09df0b8e563d60585362751cc2450fe49d915cc9
 
 COCOAPODS: 1.4.0

--- a/Pods/Target Support Files/DarklyEventSource-iOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-iOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.0</string>
+  <string>3.2.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Pods/Target Support Files/DarklyEventSource-iOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-iOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.1</string>
+  <string>3.2.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Pods/Target Support Files/DarklyEventSource-macOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-macOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.0</string>
+  <string>3.2.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Pods/Target Support Files/DarklyEventSource-macOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-macOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.1</string>
+  <string>3.2.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Pods/Target Support Files/DarklyEventSource-tvOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-tvOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.0</string>
+  <string>3.2.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Pods/Target Support Files/DarklyEventSource-tvOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-tvOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.1</string>
+  <string>3.2.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Pods/Target Support Files/DarklyEventSource-watchOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-watchOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.0</string>
+  <string>3.2.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Pods/Target Support Files/DarklyEventSource-watchOS/Info.plist
+++ b/Pods/Target Support Files/DarklyEventSource-watchOS/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.2.1</string>
+  <string>3.2.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
### Added
- `LDClient` `isOnline` readonly property that reports the online/offline status.
- `LDClient` `setOnline` method to set the online/offline status. `setOnline` may operate asynchronously, so the client calls an optional completion block when the requested operation completes.

### Changed
- Fixed potential memory leak with `DarklyEventSource`.

### Removed
- `LDClient` `online` and `offline` methods.

### Fixed
- Calling `updateUser` on `LDClient` while streaming no longer causes the SDK to request feature flags. The SDK now disconnects from the LaunchDarkly service and reconnects with the updated user.
- Calling `updateUser` on `LDClient` while polling now resets the polling timer after making a feature flag request.
