### PR TITLE
Fix header file warnings that appear for consumers of this client on Xcode 10.2

### DIFF
--- a/Darkly/DataModels/LDFlagConfig/LDEventTrackingContext.h
+++ b/Darkly/DataModels/LDFlagConfig/LDEventTrackingContext.h
@@ -18,5 +18,5 @@
 -(void)encodeWithCoder:(nonnull NSCoder*)aCoder;
 -(nullable instancetype)initWithCoder:(nonnull NSCoder*)aDecoder;
 -(nonnull NSString*)description;
--(id)copyWithZone:(nullable NSZone*)zone;
+-(nonnull id)copyWithZone:(nullable NSZone*)zone;
 @end

--- a/Darkly/DataModels/LDFlagConfig/LDFlagConfigModel.h
+++ b/Darkly/DataModels/LDFlagConfig/LDFlagConfigModel.h
@@ -28,11 +28,11 @@
 -(void)deleteFromDictionary:(nullable NSDictionary*)eventDictionary;
 
 -(BOOL)isEqualToConfig:(nullable LDFlagConfigModel*)otherConfig;
--(NSArray<NSString*>*)differingFlagKeysFromConfig:(nullable LDFlagConfigModel*)otherConfig;
+-(nullable NSArray<NSString*>*)differingFlagKeysFromConfig:(nullable LDFlagConfigModel*)otherConfig;
 -(BOOL)hasFeaturesEqualToDictionary:(nullable NSDictionary*)otherDictionary;
 
 -(void)updateEventTrackingContextFromConfig:(nullable LDFlagConfigModel*)otherConfig;
 
--(LDFlagConfigModel*)copy;
+-(nonnull LDFlagConfigModel*)copy;
 -(nonnull NSString*)description;
 @end

--- a/Darkly/DataModels/LDFlagConfig/LDFlagConfigTracker.h
+++ b/Darkly/DataModels/LDFlagConfig/LDFlagConfigTracker.h
@@ -25,5 +25,5 @@
                defaultValue:(nullable id)defaultValue;
 -(nonnull NSDictionary<NSString*, NSDictionary*>*)flagRequestSummary;
 -(nonnull NSString*)description;
--(id)copyWithZone:(nullable NSZone*)zone;
+-(nonnull id)copyWithZone:(nullable NSZone*)zone;
 @end

--- a/Darkly/DataModels/LDFlagConfig/LDFlagConfigValue.h
+++ b/Darkly/DataModels/LDFlagConfig/LDFlagConfigValue.h
@@ -43,6 +43,6 @@ extern NSInteger const kLDFlagConfigValueItemDoesNotExist;
 -(BOOL)hasPropertiesMatchingDictionary:(nullable NSDictionary*)dictionary;
 
 -(nonnull NSString*)description;
--(id)copyWithZone:(nullable NSZone*)zone;
+-(nonnull id)copyWithZone:(nullable NSZone*)zone;
 
 @end

--- a/Darkly/DataModels/LDFlagConfig/LDFlagCounter.h
+++ b/Darkly/DataModels/LDFlagConfig/LDFlagCounter.h
@@ -24,6 +24,6 @@
 -(nonnull NSDictionary*)dictionaryValue;
 
 -(nonnull NSString*)description;
--(id)copyWithZone:(nullable NSZone*)zone;
+-(nonnull id)copyWithZone:(nullable NSZone*)zone;
 
 @end

--- a/Darkly/DataModels/LDFlagConfig/LDFlagValueCounter.h
+++ b/Darkly/DataModels/LDFlagConfig/LDFlagValueCounter.h
@@ -22,6 +22,6 @@
 -(nonnull NSDictionary*)dictionaryValue;
 
 -(nonnull NSString*)description;
--(id)copyWithZone:(nullable NSZone*)zone;
+-(nonnull id)copyWithZone:(nullable NSZone*)zone;
 
 @end

--- a/Darkly/DataModels/LDUserEnvironment.h
+++ b/Darkly/DataModels/LDUserEnvironment.h
@@ -19,8 +19,8 @@
 +(nullable instancetype)userEnvironmentForUserWithKey:(nonnull NSString*)userKey environments:(nullable NSDictionary<NSString*, LDUserModel*>*)environments;
 -(nullable instancetype)initForUserWithKey:(nonnull NSString*)userKey environments:(nonnull NSDictionary<NSString*, LDUserModel*>*)environments;
 
--(nullable instancetype)initWithCoder:(NSCoder*)coder;
--(void)encodeWithCoder:(NSCoder*)coder;
+-(nullable instancetype)initWithCoder:(nonnull NSCoder*)coder;
+-(void)encodeWithCoder:(nonnull NSCoder*)coder;
 
 -(nullable instancetype)initWithDictionary:(nullable NSDictionary*)dictionary;
 -(nullable NSDictionary*)dictionaryValue;

--- a/Darkly/DataModels/LDUserModel.h
+++ b/Darkly/DataModels/LDUserModel.h
@@ -48,6 +48,6 @@ extern NSString * __nonnull const kUserAttributeCustom;
 
 -(void)resetTracker;
 
--(LDUserModel*)copy;
+-(nonnull LDUserModel*)copy;
 
 @end

--- a/Darkly/NSDictionary+LaunchDarkly.h
+++ b/Darkly/NSDictionary+LaunchDarkly.h
@@ -6,5 +6,5 @@
 
 @interface NSDictionary (LaunchDarkly)
 -(nullable NSString*) jsonString;
--(nonnull NSDictionary*)compactMapUsingBlock:(nullable id (^)(_Nonnull id originalValue))mappingBlock;
+-(nonnull NSDictionary*)compactMapUsingBlock:(id _Nullable (^_Nullable)(_Nonnull id originalValue))mappingBlock;
 @end

--- a/Darkly/Services/LDDataManager.h
+++ b/Darkly/Services/LDDataManager.h
@@ -19,13 +19,13 @@
 -(nullable instancetype)initWithMobileKey:(nonnull NSString*)mobileKey config:(nonnull LDConfig*)config;
 
 //User Store
-+(void)convertToEnvironmentBasedCacheForUser:(LDUserModel*)user config:(LDConfig*)config;
++(void)convertToEnvironmentBasedCacheForUser:(nullable LDUserModel*)user config:(nullable LDConfig*)config;
 -(void)saveUser:(nonnull LDUserModel*)user;
 -(nullable LDUserModel*)findUserWithKey:(nonnull NSString*)key;
 -(nullable LDFlagConfigModel*)retrieveFlagConfigForUser:(nonnull LDUserModel*)user;
 
 //Events
--(void)allEventDictionaries:(void (^)(NSArray * _Nullable eventDictionaries))completion;
+-(void)allEventDictionaries:(void (^_Nullable)(NSArray * _Nullable eventDictionaries))completion;
 -(void)recordFlagEvaluationEventsWithFlagKey:(nonnull NSString*)flagKey
                            reportedFlagValue:(nonnull id)reportedFlagValue
                              flagConfigValue:(nullable LDFlagConfigValue*)flagConfigValue


### PR DESCRIPTION
When consuming this code/pod/etc. in a project that is using Xcode 10.2, warnings are given due to missing nullability identifiers.  I went ahead and resolved these as best as I could based some assumptions.

This will resolve the issue: https://github.com/launchdarkly/ios-client/issues/167

Please review and let me know if I need to change any of the `nullable` identifiers to `non-null` and vice versa.