### PR TITLE
fix: #220

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Models/DiagnosticEvent.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/DiagnosticEvent.swift
@@ -19,7 +19,7 @@ protocol DiagnosticEvent {
 }
 
 struct DiagnosticInit: DiagnosticEvent, Codable {
-    let kind = DiagnosticKind.diagnosticInit
+    private(set) var kind = DiagnosticKind.diagnosticInit
     let id: DiagnosticId
     let creationDate: Int64
 
@@ -38,7 +38,7 @@ struct DiagnosticInit: DiagnosticEvent, Codable {
 }
 
 struct DiagnosticStats: DiagnosticEvent, Codable {
-    let kind = DiagnosticKind.diagnosticStats
+    private(set) var kind = DiagnosticKind.diagnosticStats
     let id: DiagnosticId
     let creationDate: Int64
 
@@ -66,7 +66,7 @@ struct DiagnosticId: Codable {
 }
 
 struct DiagnosticPlatform: Codable {
-    let name: String = "swift"
+    private(set) var name: String = "swift"
     let systemName: String
     let systemVersion: String
     let backgroundEnabled: Bool
@@ -85,7 +85,7 @@ struct DiagnosticPlatform: Codable {
 }
 
 struct DiagnosticSdk: Codable {
-    let name: String = "ios-client-sdk"
+    private(set) var name: String = "ios-client-sdk"
     let version: String
     let wrapperName: String?
     let wrapperVersion: String?


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

#220 

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen. This PR fixes the warnings mentioned in #220, which were added to the Swift compiler [somewhat recently](https://github.com/apple/swift/pull/30218). The cause of the warning is setting default values for a Decodable objects properties. This causes subtle bugs where a given property may not be correctly decoded.

The solution proposed here is one of a few, simply settings the variable to a `var` while making its setter private. This retains the original behavior for those consuming the code, while also allowing Decodable to work properly.

**Describe alternatives you've considered**

Another option would be to inject the default values when `init` is called, but that adds more arguments and some models do not have initializers to begin with, this is a smaller change. Such a change would look like this:
```swift
struct DiagnosticInit: DiagnosticEvent, Codable {
    let kind: DiagnosticKind
    let id: DiagnosticId
    let creationDate: Int64

    let sdk: DiagnosticSdk
    let configuration: DiagnosticConfig
    let platform: DiagnosticPlatform

    init(config: LDConfig, diagnosticKind: DiagnosticKind = .diagnosticInit, diagnosticId: DiagnosticId, creationDate: Int64) {
        self.kind = diagnosticKind
        self.id = diagnosticId
        self.creationDate = creationDate

        self.sdk = DiagnosticSdk(config: config)
        self.configuration = DiagnosticConfig(config: config)
        self.platform = DiagnosticPlatform(config: config)
    }
}
```

This seems possibly like something we don't really want, because it opens up the user to being able to change a value that seems like it should remain static.

**Additional context**

This is the background for the warning: https://github.com/apple/swift/pull/30218