### PR TITLE
Updates Quick to version 3.1.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "71c90eda2ab14b2110b22222d4b373163126561c",
-          "version": "3.0.1"
+          "revision": "8cce6acd38f965f5baa3167b939f86500314022b",
+          "version": "3.1.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMinor(from: "9.0.0")),
-        .package(url: "https://github.com/Quick/Quick.git", .upToNextMinor(from: "3.0.0")),
+        .package(url: "https://github.com/Quick/Quick.git", .upToNextMinor(from: "3.1.0")),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMinor(from: "9.0.0")),
         .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMinor(from: "1.2.1"))
     ],


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/Quick/Quick/issues/1046

**Describe the solution you've provided**

Updates Quick to the latest release which addresses build warnings from newer version of Xcode.

**Describe alternatives you've considered**

None considered.

**Additional context**

I did not evaluate other dependencies which might need updating. This is currently the only one that produces a top level warning when the SDK is imported into a project.
