### PR TITLE
Fixing crashes when using overflowing values

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Models/DiagnosticEvent.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/DiagnosticEvent.swift
@@ -124,12 +124,12 @@ struct DiagnosticConfig: Codable {
         customEventsURI = config.eventsUrl != LDConfig.Defaults.eventsUrl
         customStreamURI = config.streamUrl != LDConfig.Defaults.streamUrl
         eventsCapacity = config.eventCapacity
-        connectTimeoutMillis = Int(round(config.connectionTimeout * 1_000))
-        eventsFlushIntervalMillis = Int(round(config.eventFlushInterval * 1_000))
+        connectTimeoutMillis = Int(exactly: round(config.connectionTimeout * 1_000)) ?? .max
+        eventsFlushIntervalMillis = Int(exactly: round(config.eventFlushInterval * 1_000)) ?? .max
         streamingDisabled = config.streamingMode == .polling
         allAttributesPrivate = config.allUserAttributesPrivate
-        pollingIntervalMillis = Int(round(config.flagPollingInterval * 1_000))
-        backgroundPollingIntervalMillis = Int(round(config.backgroundFlagPollingInterval * 1_000))
+        pollingIntervalMillis = Int(exactly: round(config.flagPollingInterval * 1_000)) ?? .max
+        backgroundPollingIntervalMillis = Int(exactly: round(config.backgroundFlagPollingInterval * 1_000)) ?? .max
         inlineUsersInEvents = config.inlineUserInEvents
         useReport = config.useReport
         backgroundPollingDisabled = !config.enableBackgroundUpdates
@@ -137,7 +137,7 @@ struct DiagnosticConfig: Codable {
         // While the SDK treats all negative values as unlimited, for consistency we only send -1 for diagnostics
         maxCachedUsers = config.maxCachedUsers >= 0 ? config.maxCachedUsers : -1
         mobileKeyCount = 1 + (config.getSecondaryMobileKeys().count)
-        diagnosticRecordingIntervalMillis = Int(round(config.diagnosticRecordingInterval * 1_000))
+        diagnosticRecordingIntervalMillis = Int(exactly: round(config.diagnosticRecordingInterval * 1_000)) ?? .max
         customHeaders = !config.additionalHeaders.isEmpty || config.headerDelegate != nil
     }
 }

--- a/LaunchDarkly/LaunchDarklyTests/Models/DiagnosticEventSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/DiagnosticEventSpec.swift
@@ -265,6 +265,22 @@ final class DiagnosticEventSpec: QuickSpec {
                     expect(diagnosticConfig.customHeaders) == false
                 }
             }
+            context("init with overflowing config values") {
+                it("has expected values") {
+                    var overflowingConfig = customConfig
+                    overflowingConfig.backgroundFlagPollingInterval = .greatestFiniteMagnitude
+                    overflowingConfig.connectionTimeout = .greatestFiniteMagnitude
+                    overflowingConfig.diagnosticRecordingInterval = .greatestFiniteMagnitude
+                    overflowingConfig.eventFlushInterval = .greatestFiniteMagnitude
+                    overflowingConfig.flagPollingInterval = .greatestFiniteMagnitude
+                    let diagnosticConfig = DiagnosticConfig(config: overflowingConfig)
+                    expect(diagnosticConfig.backgroundPollingIntervalMillis) == Int.max
+                    expect(diagnosticConfig.connectTimeoutMillis) == Int.max
+                    expect(diagnosticConfig.diagnosticRecordingIntervalMillis) == Int.max
+                    expect(diagnosticConfig.eventsFlushIntervalMillis) == Int.max
+                    expect(diagnosticConfig.pollingIntervalMillis) == Int.max
+                }
+            }
             var diagnosticConfig: DiagnosticConfig!
             for (name, config) in [("default", defaultConfig), ("custom", customConfig)] {
                 context("with \(name) config") {


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

I didn't create a GitHub issue for this, but happy to if necessary.

**Describe the solution you've provided**

`Int(exactly:)` will return nil in case of an overflow whereas `Int(_:)` will just crash. When converting the `Double` to an `Int`, if it fails, we now use `Int.max` as a rescue.

**Describe alternatives you've considered**

Fixing the crash was I think necessary. That being said, we only noticed that crash because we wanted to disable updates to our feature flags during a user session (we want to have a consistent experience throughout the session). There's no way that I could find to do that right now, so we opted for having a _really_ long update interval.
Adding this feature would have been nice too, but was more work that I intended.

**Additional context**

Nothing else from me.