### PR TITLE
notify observers about changes rooting from an `identify` call

### DIFF
--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -304,12 +304,14 @@ public class LDClient {
             self.internalSetOnline(false)
 
             cacheConverter.convertCacheData(for: user, and: config)
+            let oldFlags = self.flagStore.featureFlags
             if let cachedFlags = self.flagCache.retrieveFeatureFlags(forUserWithKey: self.user.key, andMobileKey: self.config.mobileKey), !cachedFlags.isEmpty {
                 flagStore.replaceStore(newFlags: cachedFlags, completion: nil)
             } else {
                 // Deprecated behavior of setting flags from user init dictionary
                 flagStore.replaceStore(newFlags: user.flagStore?.featureFlags ?? [:], completion: nil)
             }
+            flagChangeNotifier.notifyObservers(oldFlags: oldFlags, newFlags: self.flagStore.featureFlags)
             self.service.user = self.user
             self.service.clearFlagResponseCache()
             flagSynchronizer = serviceFactory.makeFlagSynchronizer(streamingMode: ConnectionInformation.effectiveStreamingMode(config: config, ldClient: self),


### PR DESCRIPTION
When setting the user via `identify`, any observers were not notified about flag changes, although the underlying store changed.

This PR fixes that by calling into the "notify machinery" when swapping out the underlying data.



**Requirements**

- [-] I have added test coverage for new or changed functionality
- [-] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [-] I have validated my changes against all supported platform versions
