### PR TITLE
Avoid exposing LDSwiftEventSource as dependency, when building xcframework

### DIFF
--- a/LaunchDarkly/GeneratedCode/mocks.generated.swift
+++ b/LaunchDarkly/GeneratedCode/mocks.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 import Foundation
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 // swiftlint:disable large_tuple

--- a/LaunchDarkly/LaunchDarkly/Networking/DarklyService.swift
+++ b/LaunchDarkly/LaunchDarkly/Networking/DarklyService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 
 typealias ServiceResponse = (data: Data?, urlResponse: URLResponse?, error: Error?)
 typealias ServiceCompletionHandler = (ServiceResponse) -> Void

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/ClientServiceFactory.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/ClientServiceFactory.swift
@@ -1,5 +1,5 @@
 import Foundation
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 
 protocol ClientServiceCreating {
     func makeKeyedValueCache(cacheKey: String?) -> KeyedValueCaching

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagSynchronizer.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagSynchronizer.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Dispatch
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 
 // sourcery: autoMockable
 protocol LDFlagSynchronizing {

--- a/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 final class LDClientSpec: QuickSpec {

--- a/LaunchDarkly/LaunchDarklyTests/Mocks/ClientServiceMockFactory.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Mocks/ClientServiceMockFactory.swift
@@ -1,5 +1,5 @@
 import Foundation
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 final class ClientServiceMockFactory: ClientServiceCreating {

--- a/LaunchDarkly/LaunchDarklyTests/Mocks/DarklyServiceMock.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Mocks/DarklyServiceMock.swift
@@ -3,7 +3,7 @@ import Quick
 import Nimble
 import OHHTTPStubs
 import OHHTTPStubsSwift
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 final class DarklyServiceMock: DarklyServiceProvider {

--- a/LaunchDarkly/LaunchDarklyTests/Mocks/LDEventSourceMock.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Mocks/LDEventSourceMock.swift
@@ -1,5 +1,5 @@
 import Foundation
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 extension EventHandler {

--- a/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
@@ -2,7 +2,7 @@ import Foundation
 import Quick
 import Nimble
 import OHHTTPStubs
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 final class DarklyServiceSpec: QuickSpec {

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Quick
 import Nimble
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 final class FlagSynchronizerSpec: QuickSpec {

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/SynchronizingErrorSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/SynchronizingErrorSpec.swift
@@ -1,7 +1,6 @@
 import Foundation
 import XCTest
-
-import LDSwiftEventSource
+@_implementationOnly import LDSwiftEventSource
 @testable import LaunchDarkly
 
 final class SynchronizingErrorSpec: XCTestCase {


### PR DESCRIPTION
**Requirements**

- [/] I have added test coverage for new or changed functionality
- [/] I have followed the repository's [pull request submission guidelines](../blob/v6/CONTRIBUTING.md#submitting-pull-requests)
- [/] I have validated my changes against all supported platform versions

**Related issues**

Due to some users can't using public SPM on GitHub, using pre-build binary xcframework is a good option. But at the source code, using `import LDSwiftEventSource` will expose it as another dependency(both `LaunchDarkly.xcframework` and `LDSwiftEventSource.xcframework`) which isn't necessary.

Potential related issue: https://github.com/launchdarkly/ios-client-sdk/issues/257

**Describe the solution you've provided**

Solution👉 Mark `LDSwiftEventSource` as @ _implementationOnly will prevent it from expose as dependency: it'll remove LDSwiftEventSource from the final .swiftinterface file


<img width="651" alt="Screen Shot 2022-06-14 at 20 52 13" src="https://user-images.githubusercontent.com/720392/173547371-0c7a5b07-716a-4f35-9ea5-498bd4028bb4.png">

