### PR TITLE
feat: Add new identify method with time out support

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Models/IdentifyResult.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/IdentifyResult.swift
@@ -13,9 +13,13 @@ public enum IdentifyResult {
      */
     case error
     /**
-     The identify request has been replaced with a subsequent request. See `LDClient.identify(context: completion:)` for more details.
+     The identify request has been replaced with a subsequent request. Read `LDClient.identify(context: completion:)` for more details.
      */
     case shed
+    /**
+     The identify request exceeded some time out parameter. Read `LDClient.identify(context: timeout: completion)` for more details.
+     */
+    case timeout
 
     init(from: TaskResult) {
         switch from {


### PR DESCRIPTION
A callback provided to the `identify` method may not be executed for a long time under the right circumstances (e.g. the network is slow or unavailable).

Customers can now ensure their callbacks will fire within a specified time interval by calling the new
`LDClient.identify(context:timeout:completion:)` method.