### PR TITLE
feat: Honor polling interval between restarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - xcode-version: 15.0.1

--- a/ContractTests/Source/Controllers/SdkController.swift
+++ b/ContractTests/Source/Controllers/SdkController.swift
@@ -1,5 +1,5 @@
 import Vapor
-import LaunchDarkly
+@testable import LaunchDarkly
 
 final class SdkController: RouteCollection {
     private var clients: [Int: LDClient] = [:]
@@ -50,6 +50,8 @@ final class SdkController: RouteCollection {
             // TODO(mmk) Need to hook up initialRetryDelayMs
         } else if let polling = createInstance.configuration.polling {
             config.streamingMode = .polling
+            config.ignorePollingMinimum = true
+            config.flagPollingInterval = 0.5
             if let baseUri = polling.baseUri {
                 config.baseUrl = URL(string: baseUri)!
             }

--- a/LaunchDarkly/GeneratedCode/mocks.generated.swift
+++ b/LaunchDarkly/GeneratedCode/mocks.generated.swift
@@ -247,8 +247,8 @@ final class FeatureFlagCachingMock: FeatureFlagCaching {
     var getCachedDataCallCount = 0
     var getCachedDataCallback: (() throws -> Void)?
     var getCachedDataReceivedCacheKey: String?
-    var getCachedDataReturnValue: (items: StoredItems?, etag: String?)!
-    func getCachedData(cacheKey: String) -> (items: StoredItems?, etag: String?) {
+    var getCachedDataReturnValue: (items: StoredItems?, etag: String?, lastUpdated: Date?)!
+    func getCachedData(cacheKey: String) -> (items: StoredItems?, etag: String?, lastUpdated: Date?) {
         getCachedDataCallCount += 1
         getCachedDataReceivedCacheKey = cacheKey
         try! getCachedDataCallback?()

--- a/LaunchDarkly/LaunchDarkly/Models/LDConfig.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/LDConfig.swift
@@ -371,6 +371,10 @@ public struct LDConfig {
     /// Enables logging for debugging. (Default: false)
     public var isDebugMode: Bool = Defaults.debugMode
 
+    /// Used by the contract tests to override the default 5 minute polling interval. This should never be used outside
+    /// of the contract tests.
+    internal var ignorePollingMinimum: Bool = false
+
     /// Enables requesting evaluation reasons for all flags. (Default: false)
     public var evaluationReasons: Bool = Defaults.evaluationReasons
 
@@ -492,6 +496,10 @@ public struct LDConfig {
 
     // Determine the effective flag polling interval based on runMode, configured foreground & background polling interval, and minimum foreground & background polling interval.
     func flagPollingInterval(runMode: LDClientRunMode) -> TimeInterval {
+        if ignorePollingMinimum {
+            return runMode == .foreground ? flagPollingInterval : backgroundFlagPollingInterval
+        }
+
         return runMode == .foreground ? max(flagPollingInterval, minima.flagPollingInterval) : max(backgroundFlagPollingInterval, minima.backgroundFlagPollingInterval)
     }
 

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/FeatureFlagCache.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/FeatureFlagCache.swift
@@ -5,6 +5,17 @@ protocol FeatureFlagCaching {
     // sourcery: defaultMockValue = KeyedValueCachingMock()
     var keyedValueCache: KeyedValueCaching { get }
 
+    /// Retrieve all cached data for the given cache key.
+    ///
+    /// - parameter cacheKey: The unique key into the local cache store.
+    /// - returns: Returns a tuple of cached value information.
+    ///     items: This is the associated flag evaluation results associated with this context.
+    ///     etag: The last known e-tag value from a polling request (see saveCachedData
+    ///           comments) for more informmation.
+    ///     lastUpdated: The date the cache was last considered up-to-date. If there are no cached
+    ///            values, this should return nil.
+    ///
+    ///
     func getCachedData(cacheKey: String) -> (items: StoredItems?, etag: String?, lastUpdated: Date?)
 
     // When we update the cache, we save the flag data and if we have it, an

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/ClientServiceFactory.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/ClientServiceFactory.swift
@@ -7,10 +7,11 @@ protocol ClientServiceCreating {
     func makeFeatureFlagCache(mobileKey: String, maxCachedContexts: Int) -> FeatureFlagCaching
     func makeCacheConverter() -> CacheConverting
     func makeDarklyServiceProvider(config: LDConfig, context: LDContext, envReporter: EnvironmentReporting) -> DarklyServiceProvider
-    func makeFlagSynchronizer(streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, service: DarklyServiceProvider) -> LDFlagSynchronizing
+    func makeFlagSynchronizer(streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, lastUpdated: Date?, service: DarklyServiceProvider) -> LDFlagSynchronizing
     func makeFlagSynchronizer(streamingMode: LDStreamingMode,
                               pollingInterval: TimeInterval,
                               useReport: Bool,
+                              lastUpdated: Date?,
                               service: DarklyServiceProvider,
                               onSyncComplete: FlagSyncCompleteClosure?) -> LDFlagSynchronizing
     func makeFlagChangeNotifier() -> FlagChangeNotifying
@@ -48,16 +49,17 @@ final class ClientServiceFactory: ClientServiceCreating {
       DarklyService(config: config, context: context, envReporter: envReporter, serviceFactory: self)
     }
 
-    func makeFlagSynchronizer(streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, service: DarklyServiceProvider) -> LDFlagSynchronizing {
-        makeFlagSynchronizer(streamingMode: streamingMode, pollingInterval: pollingInterval, useReport: useReport, service: service, onSyncComplete: nil)
+    func makeFlagSynchronizer(streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, lastUpdated: Date?, service: DarklyServiceProvider) -> LDFlagSynchronizing {
+        makeFlagSynchronizer(streamingMode: streamingMode, pollingInterval: pollingInterval, useReport: useReport, lastUpdated: lastUpdated, service: service, onSyncComplete: nil)
     }
 
     func makeFlagSynchronizer(streamingMode: LDStreamingMode,
                               pollingInterval: TimeInterval,
                               useReport: Bool,
+                              lastUpdated: Date?,
                               service: DarklyServiceProvider,
                               onSyncComplete: FlagSyncCompleteClosure?) -> LDFlagSynchronizing {
-        FlagSynchronizer(streamingMode: streamingMode, pollingInterval: pollingInterval, useReport: useReport, service: service, onSyncComplete: onSyncComplete)
+        FlagSynchronizer(streamingMode: streamingMode, pollingInterval: pollingInterval, useReport: useReport, lastUpdated: lastUpdated, service: service, onSyncComplete: onSyncComplete)
     }
 
     func makeFlagChangeNotifier() -> FlagChangeNotifying {

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagSynchronizer.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagSynchronizer.swift
@@ -79,6 +79,7 @@ class FlagSynchronizer: LDFlagSynchronizing, EventHandler {
     private var isOnlineQueue = DispatchQueue(label: "com.launchdarkly.FlagSynchronizer.isOnlineQueue")
     let pollingInterval: TimeInterval
     let useReport: Bool
+    private var lastCachedRequestedTime: Date?
 
     private var syncQueue = DispatchQueue(label: Constants.queueName, qos: .utility)
     private var eventSourceStarted: Date?
@@ -86,11 +87,13 @@ class FlagSynchronizer: LDFlagSynchronizing, EventHandler {
     init(streamingMode: LDStreamingMode,
          pollingInterval: TimeInterval,
          useReport: Bool,
+         lastUpdated: Date?,
          service: DarklyServiceProvider,
          onSyncComplete: FlagSyncCompleteClosure?) {
         self.streamingMode = streamingMode
         self.pollingInterval = pollingInterval
         self.useReport = useReport
+        self.lastCachedRequestedTime = lastUpdated
         self.service = service
         self.onSyncComplete = onSyncComplete
         os_log("%s streamingMode: %s pollingInterval: %s useReport: %s", log: service.config.logger, type: .debug, typeName(and: #function), String(describing: streamingMode), String(describing: pollingInterval), useReport.description)
@@ -151,9 +154,15 @@ class FlagSynchronizer: LDFlagSynchronizing, EventHandler {
             return
         }
 
+        if let lastTime = self.lastCachedRequestedTime {
+            let fireAt = lastTime.addingTimeInterval(pollingInterval)
+            flagRequestTimer = LDTimer(withTimeInterval: pollingInterval, fireQueue: syncQueue, fireAt: fireAt, execute: processTimer)
+            syncQueue.async { [self] in reportSyncComplete(.upToDate) }
+        } else {
+            flagRequestTimer = LDTimer(withTimeInterval: pollingInterval, fireQueue: syncQueue, execute: processTimer)
+            makeFlagRequest(isOnline: true)
+        }
         os_log("%s", log: service.config.logger, type: .debug, typeName(and: #function))
-        flagRequestTimer = LDTimer(withTimeInterval: pollingInterval, fireQueue: syncQueue, execute: processTimer)
-        makeFlagRequest(isOnline: true)
     }
 
     private func stopPolling() {
@@ -184,6 +193,9 @@ class FlagSynchronizer: LDFlagSynchronizing, EventHandler {
         os_log("%s starting", log: service.config.logger, type: .debug, typeName(and: #function))
         let context = (useReport: useReport,
                        logPrefix: typeName(and: #function))
+        // We blank this value here so that future `startPolling` requests do
+        // not prematurely trigger the sync completion.
+        self.lastCachedRequestedTime = nil
         service.getFeatureFlags(useReport: useReport) { [weak self] serviceResponse in
             if FlagSynchronizer.shouldRetryFlagRequest(useReport: context.useReport, statusCode: (serviceResponse.urlResponse as? HTTPURLResponse)?.statusCode) {
                 if let myself = self {

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagSynchronizer.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagSynchronizer.swift
@@ -159,7 +159,7 @@ class FlagSynchronizer: LDFlagSynchronizing, EventHandler {
         var fireAt = Date.distantPast
         if let lastTime = self.lastCachedRequestedTime {
             fireAt = lastTime.addingTimeInterval(pollingInterval)
-            // If we do consider the cached values already fresh enough, we should 
+            // If we do consider the cached values already fresh enough, we should
             // signal completion immediately
             syncQueue.async { [self] in reportSyncComplete(.upToDate) }
         }

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/LDTimer.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/LDTimer.swift
@@ -3,7 +3,7 @@ import Foundation
 protocol TimeResponding {
     var fireDate: Date? { get }
 
-    init(withTimeInterval: TimeInterval, fireQueue: DispatchQueue, execute: @escaping () -> Void)
+    init(withTimeInterval: TimeInterval, fireQueue: DispatchQueue, fireAt: Date?, execute: @escaping () -> Void)
     func cancel()
 }
 
@@ -15,12 +15,17 @@ final class LDTimer: TimeResponding {
     private (set) var isCancelled: Bool = false
     var fireDate: Date? { timer?.fireDate }
 
-    init(withTimeInterval timeInterval: TimeInterval, fireQueue: DispatchQueue = DispatchQueue.main, execute: @escaping () -> Void) {
+    init(withTimeInterval timeInterval: TimeInterval, fireQueue: DispatchQueue = DispatchQueue.main, fireAt: Date? = nil, execute: @escaping () -> Void) {
         self.fireQueue = fireQueue
         self.execute = execute
 
         // the run loop retains the timer, so the property is weak to avoid a retain cycle. Setting the timer to a strong reference is important so that the timer doesn't get nil'd before it's added to the run loop.
-        let timer = Timer(timeInterval: timeInterval, target: self, selector: #selector(timerFired), userInfo: nil, repeats: true)
+        let timer: Timer
+        if let at = fireAt {
+            timer = Timer(fireAt: at, interval: timeInterval, target: self, selector: #selector(timerFired), userInfo: nil, repeats: true)
+        } else {
+            timer = Timer(timeInterval: timeInterval, target: self, selector: #selector(timerFired), userInfo: nil, repeats: true)
+        }
         self.timer = timer
         RunLoop.main.add(timer, forMode: RunLoop.Mode.default)
     }

--- a/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
@@ -89,7 +89,7 @@ final class LDClientSpec: QuickSpec {
                 let mobileKey = self.serviceFactoryMock.makeFeatureFlagCacheReceivedParameters!.mobileKey
                 let mockCache = FeatureFlagCachingMock()
                 mockCache.getCachedDataCallback = {
-                    mockCache.getCachedDataReturnValue = (items: StoredItems(items: self.cachedFlags[mobileKey]?[mockCache.getCachedDataReceivedCacheKey!] ?? [:]), etag: nil)
+                    mockCache.getCachedDataReturnValue = (items: StoredItems(items: self.cachedFlags[mobileKey]?[mockCache.getCachedDataReceivedCacheKey!] ?? [:]), etag: nil, lastUpdated: nil)
                 }
                 self.serviceFactoryMock.makeFeatureFlagCacheReturnValue = mockCache
             }
@@ -503,7 +503,7 @@ final class LDClientSpec: QuickSpec {
                             expect(testContext.serviceFactoryMock.makeEventReporterReceivedService?.context) == testContext.context
                         }
                         it("uncaches the new contexts flags") {
-                            expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
+                            expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 2
                             expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
                         }
                         it("records an identify event") {
@@ -542,7 +542,7 @@ final class LDClientSpec: QuickSpec {
                             expect(testContext.serviceFactoryMock.makeEventReporterReceivedService?.context) == testContext.context
                         }
                         it("uncaches the new contexts flags") {
-                            expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
+                            expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 2
                             expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
                         }
                         it("records an identify event") {

--- a/LaunchDarkly/LaunchDarklyTests/Mocks/ClientServiceMockFactory.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Mocks/ClientServiceMockFactory.swift
@@ -39,15 +39,16 @@ final class ClientServiceMockFactory: ClientServiceCreating {
     }
 
     var makeFlagSynchronizerCallCount = 0
-    var makeFlagSynchronizerReceivedParameters: (streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, service: DarklyServiceProvider)? = nil
+    var makeFlagSynchronizerReceivedParameters: (streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, lastUpdated: Date?, service: DarklyServiceProvider)? = nil
     var onFlagSyncComplete: FlagSyncCompleteClosure? = nil
     func makeFlagSynchronizer(streamingMode: LDStreamingMode,
                               pollingInterval: TimeInterval,
                               useReport: Bool,
+                              lastUpdated: Date?,
                               service: DarklyServiceProvider,
                               onSyncComplete: FlagSyncCompleteClosure?) -> LDFlagSynchronizing {
         makeFlagSynchronizerCallCount += 1
-        makeFlagSynchronizerReceivedParameters = (streamingMode, pollingInterval, useReport, service)
+        makeFlagSynchronizerReceivedParameters = (streamingMode, pollingInterval, useReport, lastUpdated, service)
         onFlagSyncComplete = onSyncComplete
 
         let flagSynchronizingMock = LDFlagSynchronizingMock()
@@ -56,8 +57,8 @@ final class ClientServiceMockFactory: ClientServiceCreating {
         return flagSynchronizingMock
     }
 
-    func makeFlagSynchronizer(streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, service: DarklyServiceProvider) -> LDFlagSynchronizing {
-        makeFlagSynchronizer(streamingMode: streamingMode, pollingInterval: pollingInterval, useReport: useReport, service: service, onSyncComplete: nil)
+    func makeFlagSynchronizer(streamingMode: LDStreamingMode, pollingInterval: TimeInterval, useReport: Bool, lastUpdated: Date?, service: DarklyServiceProvider) -> LDFlagSynchronizing {
+        makeFlagSynchronizer(streamingMode: streamingMode, pollingInterval: pollingInterval, useReport: useReport, lastUpdated: lastUpdated, service: service, onSyncComplete: nil)
     }
 
     var makeFlagChangeNotifierReturnValue: FlagChangeNotifying = FlagChangeNotifyingMock()

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/FeatureFlagCacheSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/FeatureFlagCacheSpec.swift
@@ -27,10 +27,11 @@ final class FeatureFlagCacheSpec: XCTestCase {
 
     func testRetrieveNoData() {
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 0)
-        let (items, etag) = flagCache.getCachedData(cacheKey: "context1")
+        let (items, etag, lastUpdated) = flagCache.getCachedData(cacheKey: "context1")
 
         XCTAssertNil(items)
         XCTAssertNil(etag)
+        XCTAssertNil(lastUpdated)
         XCTAssertEqual(mockValueCache.dataCallCount, 1)
         XCTAssertEqual(mockValueCache.dataReceivedForKey, "flags-context1")
     }
@@ -38,10 +39,11 @@ final class FeatureFlagCacheSpec: XCTestCase {
     func testRetrieveInvalidData() {
         mockValueCache.dataReturnValue = Data("invalid".utf8)
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 1)
-        let (items, etag) = flagCache.getCachedData(cacheKey: "context1")
+        let (items, etag, lastUpdated) = flagCache.getCachedData(cacheKey: "context1")
 
         XCTAssertNil(items)
         XCTAssertNil(etag)
+        XCTAssertNil(lastUpdated)
     }
 
     func testRetrieveEmptyData() throws {

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
@@ -118,7 +118,6 @@ final class FlagSynchronizerSpec: QuickSpec {
                             semaphore.signal()
                         }
                         testContext.flagSynchronizer.isOnline = true
-                        testContext.flagSynchronizer.isOnline = false
                     }
 
                     let runLoop = RunLoop.current
@@ -126,6 +125,7 @@ final class FlagSynchronizerSpec: QuickSpec {
                     while semaphore.wait(timeout: .now()) == .timedOut {
                         runLoop.run(mode: .default, before: .distantFuture)
                     }
+                    testContext.flagSynchronizer.isOnline = false
 
                     expect(testContext.flagSynchronizer.isOnline) == false
                     expect(testContext.flagSynchronizer.streamingMode) == .polling

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
@@ -28,6 +28,7 @@ final class FlagSynchronizerSpec: QuickSpec {
             flagSynchronizer = FlagSynchronizer(streamingMode: streamingMode,
                                                 pollingInterval: Constants.pollingInterval,
                                                 useReport: useReport,
+                                                lastUpdated: nil,
                                                 service: serviceMock,
                                                 onSyncComplete: onSyncComplete)
         }


### PR DESCRIPTION
If an application receives a flag update and then is closed, only to be opened back up, we shouldn't need to make another polling request immediately as the data is within the acceptable freshness threshold.

The same is true when the app is put in the background and brought forward again.