### PR TITLE
fix: Add missing privacy tracking fields in manifest

### DIFF
--- a/LaunchDarkly/LaunchDarkly/PrivacyInfo.xcprivacy
+++ b/LaunchDarkly/LaunchDarkly/PrivacyInfo.xcprivacy
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The [documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) seems to suggest you should set all 4 of these fields. So I'm doing that for completeness.