### PR TITLE
fix: Mark  NSPrivacyCollectedDataTypeTracking as false in privacy manifest

### DIFF
--- a/LaunchDarkly/LaunchDarkly/PrivacyInfo.xcprivacy
+++ b/LaunchDarkly/LaunchDarkly/PrivacyInfo.xcprivacy
@@ -14,7 +14,7 @@
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<true/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<true/>
+			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
 				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
@@ -28,7 +28,7 @@
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<true/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<true/>
+			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
 				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>


### PR DESCRIPTION
According to
https://developer.apple.com/app-store/user-privacy-and-data-use/

> Tracking refers to the act of linking user or device data collected
from your app with user or device data collected from other companies’ apps, websites, or offline properties for targeted advertising or advertising measurement purposes.

The data we collect is not used for advertising.