### PR TITLE
fix: start time warning log now uses float wildcard for string interpolation of time interval

### DIFF
--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -355,7 +355,7 @@ public class LDClient {
      */
     public func identify(context: LDContext, timeout: TimeInterval, completion: @escaping ((_ result: IdentifyResult) -> Void)) {
         if timeout > LDClient.longTimeoutInterval {
-            os_log("%s LDClient.identify was called with a timeout greater than %d seconds. We recommend a timeout of less than %s seconds.", log: config.logger, type: .debug, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
+            os_log("%s LDClient.identify was called with a timeout greater than %f seconds. We recommend a timeout of less than %f seconds.", log: config.logger, type: .info, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
         }
 
         var cancel = false
@@ -789,7 +789,7 @@ public class LDClient {
     */
     public static func start(config: LDConfig, context: LDContext? = nil, startWaitSeconds: TimeInterval, completion: ((_ timedOut: Bool) -> Void)? = nil) {
         if startWaitSeconds > LDClient.longTimeoutInterval {
-            os_log("%s LDClient.start was called with a timeout greater than %d seconds. We recommend a timeout of less than %s seconds.", log: config.logger, type: .debug, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
+            os_log("%s LDClient.start was called with a timeout greater than %f seconds. We recommend a timeout of less than %f seconds.", log: config.logger, type: .info, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
         }
 
         start(serviceFactory: nil, config: config, context: context, startWaitSeconds: startWaitSeconds, completion: completion)


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
N/A

- [x] I have followed the repository's [pull request submission guidelines](../blob/v9/CONTRIBUTING.md#submitting-pull-requests)

- [ ] I have validated my changes against all supported platform versions
I do not have a Mac with Apple Silicon which was the original source of this report, will have to have customer verify.

**Related issues**

SC-246543