### PR TITLE
fix: Sort private attributes for improved stable encoding

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Models/Context/LDContext.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Context/LDContext.swift
@@ -97,7 +97,8 @@ public struct LDContext: Encodable, Equatable {
             let includePrivateAttributes = encoder.userInfo[UserInfoKeys.includePrivateAttributes] as? Bool ?? false
 
             if let privateAttributes = privateAttributes, !privateAttributes.isEmpty, includePrivateAttributes {
-                try container.encodeIfPresent(privateAttributes, forKey: .privateAttributes)
+                let sorted = privateAttributes.sorted { $0.raw() < $1.raw() }
+                try container.encodeIfPresent(sorted, forKey: .privateAttributes)
             }
 
             if let redactedAttributes = redactedAttributes, !redactedAttributes.isEmpty {


### PR DESCRIPTION
To help increase cache hits, we want to always use a stable encoding for the context. This was done in a previous commit when we added the `encoder.outputFormatting = [.sortedKeys]` modification.

A context's private attributes are sorted as a set, which makes no guarantee about encoding order. To address this, we are sorting the private attributes prior to the JSON encoding phase. As a result, we would expect to see an increase in cache hits for customers.