### PR TITLE
feat: Update caching strategy to allow for greater cache use

### DIFF
--- a/LaunchDarkly/GeneratedCode/mocks.generated.swift
+++ b/LaunchDarkly/GeneratedCode/mocks.generated.swift
@@ -246,21 +246,21 @@ final class FeatureFlagCachingMock: FeatureFlagCaching {
 
     var getCachedDataCallCount = 0
     var getCachedDataCallback: (() throws -> Void)?
-    var getCachedDataReceivedCacheKey: String?
+    var getCachedDataReceivedArguments: (cacheKey: String, contextHash: String)?
     var getCachedDataReturnValue: (items: StoredItems?, etag: String?, lastUpdated: Date?)!
-    func getCachedData(cacheKey: String) -> (items: StoredItems?, etag: String?, lastUpdated: Date?) {
+    func getCachedData(cacheKey: String, contextHash: String) -> (items: StoredItems?, etag: String?, lastUpdated: Date?) {
         getCachedDataCallCount += 1
-        getCachedDataReceivedCacheKey = cacheKey
+        getCachedDataReceivedArguments = (cacheKey: cacheKey, contextHash: contextHash)
         try! getCachedDataCallback?()
         return getCachedDataReturnValue
     }
 
     var saveCachedDataCallCount = 0
     var saveCachedDataCallback: (() throws -> Void)?
-    var saveCachedDataReceivedArguments: (storedItems: StoredItems, cacheKey: String, lastUpdated: Date, etag: String?)?
-    func saveCachedData(_ storedItems: StoredItems, cacheKey: String, lastUpdated: Date, etag: String?) {
+    var saveCachedDataReceivedArguments: (storedItems: StoredItems, cacheKey: String, contextHash: String, lastUpdated: Date, etag: String?)?
+    func saveCachedData(_ storedItems: StoredItems, cacheKey: String, contextHash: String, lastUpdated: Date, etag: String?) {
         saveCachedDataCallCount += 1
-        saveCachedDataReceivedArguments = (storedItems: storedItems, cacheKey: cacheKey, lastUpdated: lastUpdated, etag: etag)
+        saveCachedDataReceivedArguments = (storedItems: storedItems, cacheKey: cacheKey, contextHash: contextHash, lastUpdated: lastUpdated, etag: etag)
         try! saveCachedDataCallback?()
     }
 }

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -208,7 +208,7 @@ public class LDClient {
                 return
             }
 
-            let cachedData = self.flagCache.getCachedData(cacheKey: self.context.contextHash())
+            let cachedData = self.flagCache.getCachedData(cacheKey: self.context.fullyQualifiedHashedKey(), contextHash: self.context.contextHash())
 
             let willSetSynchronizerOnline = isOnline && isInSupportedRunMode
             flagSynchronizer.isOnline = false
@@ -393,7 +393,7 @@ public class LDClient {
             let wasOnline = self.isOnline
             self.internalSetOnline(false)
 
-            let cachedData = self.flagCache.getCachedData(cacheKey: self.context.contextHash())
+            let cachedData = self.flagCache.getCachedData(cacheKey: self.context.fullyQualifiedHashedKey(), contextHash: self.context.contextHash())
             let cachedContextFlags = cachedData.items ?? [:]
             let oldItems = flagStore.storedItems.featureFlags
 
@@ -629,7 +629,7 @@ public class LDClient {
 
     private func updateCacheAndReportChanges(context: LDContext,
                                              oldStoredItems: StoredItems, etag: String?) {
-        flagCache.saveCachedData(flagStore.storedItems, cacheKey: context.contextHash(), lastUpdated: Date(), etag: etag)
+        flagCache.saveCachedData(flagStore.storedItems, cacheKey: context.fullyQualifiedHashedKey(), contextHash: context.contextHash(), lastUpdated: Date(), etag: etag)
         flagChangeNotifier.notifyObservers(oldFlags: oldStoredItems.featureFlags, newFlags: flagStore.storedItems.featureFlags)
     }
 
@@ -641,7 +641,7 @@ public class LDClient {
      In other words, if we get confirmation our cache is still fresh, then we shouldn't poll again for another <pollingInterval> seconds. If we didn't update this, we would poll immediately on restart.
     */
     private func updateCacheFreshness(context: LDContext) {
-        flagCache.saveCachedData(flagStore.storedItems, cacheKey: context.contextHash(), lastUpdated: Date(), etag: nil)
+        flagCache.saveCachedData(flagStore.storedItems, cacheKey: context.fullyQualifiedHashedKey(), contextHash: context.contextHash(), lastUpdated: Date(), etag: nil)
     }
 
     // MARK: Events
@@ -881,7 +881,7 @@ public class LDClient {
         diagnosticReporter = self.serviceFactory.makeDiagnosticReporter(service: service, environmentReporter: environmentReporter)
         eventReporter = self.serviceFactory.makeEventReporter(service: service)
         connectionInformation = self.serviceFactory.makeConnectionInformation()
-        let cachedData = flagCache.getCachedData(cacheKey: context.contextHash())
+        let cachedData = flagCache.getCachedData(cacheKey: context.fullyQualifiedHashedKey(), contextHash: context.contextHash())
         flagSynchronizer = self.serviceFactory.makeFlagSynchronizer(streamingMode: config.allowStreamingMode ? config.streamingMode : .polling,
                                                                     pollingInterval: config.flagPollingInterval(runMode: runMode),
                                                                     useReport: config.useReport,

--- a/LaunchDarkly/LaunchDarkly/Models/Context/LDContext.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Context/LDContext.swift
@@ -364,12 +364,12 @@ public struct LDContext: Encodable, Equatable {
         encoder.userInfo[UserInfoKeys.redactAttributes] = false
 
         guard let json = try? encoder.encode(self)
-        else { return fullyQualifiedKey() }
+        else { return fullyQualifiedHashedKey() }
 
         if let jsonStr = String(data: json, encoding: .utf8) {
             return Util.sha256base64(jsonStr)
         }
-        return fullyQualifiedKey()
+        return fullyQualifiedHashedKey()
     }
 
     /// - Returns: true if the `LDContext` is a multi-context; false otherwise.

--- a/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
@@ -93,7 +93,7 @@ final class LDClientSpec: QuickSpec {
             }
             it("uncaches the new contexts flags") {
                 expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
-                expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
+                expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
             }
             it("records an identify event") {
                 expect(testContext.eventReporterMock.recordCallCount) == 1
@@ -136,7 +136,7 @@ final class LDClientSpec: QuickSpec {
             }
             it("uncaches the new contexts flags") {
                 expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
-                expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
+                expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
             }
             it("records an identify event") {
                 expect(testContext.eventReporterMock.recordCallCount) == 1
@@ -178,7 +178,7 @@ final class LDClientSpec: QuickSpec {
                 }
                 it("uncaches the new contexts flags") {
                     expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 2 // called on init and subsequent identify
-                    expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
+                    expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
                 }
                 it("records an identify event") {
                     expect(testContext.eventReporterMock.recordCallCount) == 2 // both start and internalIdentify
@@ -210,7 +210,7 @@ final class LDClientSpec: QuickSpec {
                 }
                 it("uncaches the new contexts flags") {
                     expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
-                    expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.subject.context.contextHash()
+                    expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.subject.context.fullyQualifiedHashedKey()
                 }
                 it("records an identify event") {
                     expect(testContext.eventReporterMock.recordCallCount) == 1
@@ -229,7 +229,7 @@ final class LDClientSpec: QuickSpec {
             withTimeout ? testContext.start(timeOut: 10.0) : testContext.start()
 
             expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
-            expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
+            expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
 
             expect(testContext.flagStoreMock.replaceStoreReceivedNewFlags) == cachedFlags
 
@@ -242,7 +242,7 @@ final class LDClientSpec: QuickSpec {
             withTimeout ? testContext.start(timeOut: 10.0) : testContext.start()
 
             expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
-            expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
+            expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
 
             expect(testContext.flagStoreMock.replaceStoreCallCount) == 0
 
@@ -383,7 +383,7 @@ final class LDClientSpec: QuickSpec {
                         }
                         it("uncaches the new contexts flags") {
                             expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 2
-                            expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
+                            expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
                         }
                         it("records an identify event") {
                             expect(testContext.eventReporterMock.recordCallCount) == 1
@@ -422,7 +422,7 @@ final class LDClientSpec: QuickSpec {
                         }
                         it("uncaches the new contexts flags") {
                             expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 2
-                            expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == testContext.context.contextHash()
+                            expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
                         }
                         it("records an identify event") {
                             expect(testContext.eventReporterMock.recordCallCount) == 1
@@ -454,7 +454,7 @@ final class LDClientSpec: QuickSpec {
                 expect(testContext.subject.flagSynchronizer.isOnline) == true
 
                 expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
-                expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == newContext.contextHash()
+                expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == newContext.fullyQualifiedHashedKey()
 
                 expect(testContext.eventReporterMock.recordReceivedEvent?.kind == .identify).to(beTrue())
             }
@@ -476,14 +476,14 @@ final class LDClientSpec: QuickSpec {
                 expect(testContext.subject.flagSynchronizer.isOnline) == false
 
                 expect(testContext.featureFlagCachingMock.getCachedDataCallCount) == 1
-                expect(testContext.featureFlagCachingMock.getCachedDataReceivedCacheKey) == newContext.contextHash()
+                expect(testContext.featureFlagCachingMock.getCachedDataReceivedArguments?.cacheKey) == newContext.fullyQualifiedHashedKey()
 
                 expect(testContext.eventReporterMock.recordReceivedEvent?.kind == .identify).to(beTrue())
             }
             it("when the new context has cached feature flags") {
                 let stubFlags = FlagMaintainingMock.stubStoredItems()
                 let newContext = LDContext.stub()
-                let testContext = TestContext().withCached(contextKey: newContext.contextHash(), flags: stubFlags.featureFlags)
+                let testContext = TestContext().withCached(contextKey: newContext.fullyQualifiedHashedKey(), flags: stubFlags.featureFlags)
                 testContext.start()
                 testContext.featureFlagCachingMock.reset()
 
@@ -819,7 +819,7 @@ final class LDClientSpec: QuickSpec {
 
         expect(testContext.featureFlagCachingMock.saveCachedDataCallCount) == 1
         expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.storedItems) == newStoredItems
-        expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.cacheKey) == testContext.context.contextHash()
+        expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
         expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.lastUpdated).to(beCloseTo(updateDate, within: Constants.updateThreshold))
 
         expect(testContext.changeNotifierMock.notifyObserversCallCount) == 1
@@ -846,7 +846,7 @@ final class LDClientSpec: QuickSpec {
 
         expect(testContext.featureFlagCachingMock.saveCachedDataCallCount) == 1
         expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.storedItems) == testContext.flagStoreMock.storedItems
-        expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.cacheKey) == testContext.context.contextHash()
+        expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
         expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.lastUpdated).to(beCloseTo(updateDate, within: Constants.updateThreshold))
 
         expect(testContext.changeNotifierMock.notifyObserversCallCount) == 1
@@ -873,7 +873,7 @@ final class LDClientSpec: QuickSpec {
 
         expect(testContext.featureFlagCachingMock.saveCachedDataCallCount) == 1
         expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.storedItems.featureFlags) == testContext.flagStoreMock.storedItems.featureFlags
-        expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.cacheKey) == testContext.context.contextHash()
+        expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.cacheKey) == testContext.context.fullyQualifiedHashedKey()
         expect(testContext.featureFlagCachingMock.saveCachedDataReceivedArguments?.lastUpdated).to(beCloseTo(updateDate, within: Constants.updateThreshold))
 
         expect(testContext.changeNotifierMock.notifyObserversCallCount) == 1
@@ -1303,7 +1303,6 @@ final class LDClientSpec: QuickSpec {
 extension FeatureFlagCachingMock {
     func reset() {
         getCachedDataCallCount = 0
-        getCachedDataReceivedCacheKey = nil
         getCachedDataReturnValue = nil
         saveCachedDataCallCount = 0
         saveCachedDataReceivedArguments = nil

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/FeatureFlagCacheSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/FeatureFlagCacheSpec.swift
@@ -27,7 +27,7 @@ final class FeatureFlagCacheSpec: XCTestCase {
 
     func testRetrieveNoData() {
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 0)
-        let (items, etag, lastUpdated) = flagCache.getCachedData(cacheKey: "context1")
+        let (items, etag, lastUpdated) = flagCache.getCachedData(cacheKey: "context1", contextHash: "contextHash")
 
         XCTAssertNil(items)
         XCTAssertNil(etag)
@@ -39,7 +39,7 @@ final class FeatureFlagCacheSpec: XCTestCase {
     func testRetrieveInvalidData() {
         mockValueCache.dataReturnValue = Data("invalid".utf8)
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 1)
-        let (items, etag, lastUpdated) = flagCache.getCachedData(cacheKey: "context1")
+        let (items, etag, lastUpdated) = flagCache.getCachedData(cacheKey: "context1", contextHash: "contextHash")
 
         XCTAssertNil(items)
         XCTAssertNil(etag)
@@ -49,24 +49,57 @@ final class FeatureFlagCacheSpec: XCTestCase {
     func testRetrieveEmptyData() throws {
         mockValueCache.dataReturnValue = try JSONEncoder().encode(StoredItemCollection([:]))
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 2)
-        XCTAssertEqual(flagCache.getCachedData(cacheKey: "context1").items?.count, 0)
+        XCTAssertEqual(flagCache.getCachedData(cacheKey: "context1", contextHash: "context").items?.count, 0)
     }
 
     func testRetrieveValidData() throws {
         mockValueCache.dataReturnValue = try JSONEncoder().encode(testFlagCollection)
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 1)
-        let retrieved = flagCache.getCachedData(cacheKey: "context1")
+        let retrieved = flagCache.getCachedData(cacheKey: "context1", contextHash: "contextHash")
         XCTAssertEqual(retrieved.items, testFlagCollection.flags)
         XCTAssertEqual(mockValueCache.dataCallCount, 2)
-        XCTAssertEqual(mockValueCache.dataReceivedForKey, "etag-context1")
+        XCTAssertEqual(mockValueCache.dataReceivedForKey, "fingerprint-context1")
     }
 
     func testStoreCacheDisabled() {
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 0)
-        flagCache.saveCachedData([:], cacheKey: "context1", lastUpdated: Date(), etag: nil)
+        flagCache.saveCachedData([:], cacheKey: "context1", contextHash: "context", lastUpdated: Date(), etag: nil)
         XCTAssertEqual(mockValueCache.setCallCount, 0)
         XCTAssertEqual(mockValueCache.dataCallCount, 0)
         XCTAssertEqual(mockValueCache.removeObjectCallCount, 0)
+    }
+
+    func testCanReuseFullCacheIfHashIsSame() {
+        let now = Date()
+        let flagCache = FeatureFlagCache(serviceFactory: ClientServiceFactory(logger: .disabled), mobileKey: "abc", maxCachedContexts: 5)
+        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: "key", contextHash: "hash", lastUpdated: now, etag: "example-etag")
+
+        let results = flagCache.getCachedData(cacheKey: "key", contextHash: "hash")
+        XCTAssertEqual(results.items, testFlagCollection.flags)
+        XCTAssertEqual(results.etag, "example-etag")
+        XCTAssertEqual(results.lastUpdated!.millisSince1970, now.millisSince1970, accuracy: 1_000)
+    }
+
+    func testCanReusePartialCacheIfOnlyHashChanges() {
+        let now = Date()
+        let flagCache = FeatureFlagCache(serviceFactory: ClientServiceFactory(logger: .disabled), mobileKey: "abc", maxCachedContexts: 5)
+        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: "key", contextHash: "hash", lastUpdated: now, etag: "example-etag")
+
+        let results = flagCache.getCachedData(cacheKey: "key", contextHash: "changed-hash")
+        XCTAssertEqual(results.items, testFlagCollection.flags)
+        XCTAssertEqual(results.etag, nil)
+        XCTAssertEqual(results.lastUpdated, nil)
+    }
+
+    func testCannotReuseCacheIfKeyChanges() {
+     let now = Date()
+        let flagCache = FeatureFlagCache(serviceFactory: ClientServiceFactory(logger: .disabled), mobileKey: "abc", maxCachedContexts: 5)
+        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: "key", contextHash: "hash", lastUpdated: now, etag: "example-etag")
+
+        let results = flagCache.getCachedData(cacheKey: "changed-key", contextHash: "hash")
+        XCTAssertEqual(results.items, nil)
+        XCTAssertEqual(results.etag, nil)
+        XCTAssertEqual(results.lastUpdated, nil)
     }
 
     func testStoreEmptyData() throws {
@@ -77,15 +110,17 @@ final class FeatureFlagCacheSpec: XCTestCase {
                 let setData = self.mockValueCache.setReceivedArguments!.value
                 XCTAssertEqual(setData, try JSONEncoder().encode(["context1": now.millisSince1970]))
                 count += 1
+            } else if self.mockValueCache.setReceivedArguments?.forKey == "fingerprint-context1" {
+                count += 2
             } else if let received = self.mockValueCache.setReceivedArguments {
                 XCTAssertEqual(received.forKey, "flags-context1")
                 XCTAssertEqual(received.value, try JSONEncoder().encode(StoredItemCollection([:])))
-                count += 2
+                count += 3
             }
         }
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: -1)
-        flagCache.saveCachedData([:], cacheKey: "context1", lastUpdated: now, etag: nil)
-        XCTAssertEqual(count, 3)
+        flagCache.saveCachedData([:], cacheKey: "context1", contextHash: "context", lastUpdated: now, etag: nil)
+        XCTAssertEqual(count, 6)
     }
 
     func testStoreValidData() throws {
@@ -95,8 +130,8 @@ final class FeatureFlagCacheSpec: XCTestCase {
             }
         }
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 1)
-        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: "context1", lastUpdated: Date(), etag: nil)
-        XCTAssertEqual(mockValueCache.setCallCount, 2)
+        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: "context1", contextHash: "context", lastUpdated: Date(), etag: nil)
+        XCTAssertEqual(mockValueCache.setCallCount, 3)
     }
 
     func testStoreMaxCachedContextsStored() throws {
@@ -105,9 +140,9 @@ final class FeatureFlagCacheSpec: XCTestCase {
         let earlier = now.addingTimeInterval(-30.0)
         mockValueCache.dataReturnValue = try JSONEncoder().encode(["key1": earlier.millisSince1970])
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 1)
-        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: hashedContextKey, lastUpdated: now, etag: nil)
-        XCTAssertEqual(mockValueCache.removeObjectCallCount, 2)
-        XCTAssertEqual(mockValueCache.removeObjectReceivedForKey, "etag-key1")
+        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: hashedContextKey, contextHash: "context", lastUpdated: now, etag: nil)
+        XCTAssertEqual(mockValueCache.removeObjectCallCount, 3)
+        XCTAssertEqual(mockValueCache.removeObjectReceivedForKey, "fingerprint-key1")
         let setMetadata = try JSONDecoder().decode([String: Int64].self, from: mockValueCache.setReceivedArguments!.value)
         XCTAssertEqual(setMetadata, [hashedContextKey: now.millisSince1970])
     }
@@ -123,8 +158,8 @@ final class FeatureFlagCacheSpec: XCTestCase {
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 2)
         var removedObjects: [String] = []
         mockValueCache.removeObjectCallback = { removedObjects.append(self.mockValueCache.removeObjectReceivedForKey!) }
-        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: hashedContextKey, lastUpdated: later, etag: nil)
-        XCTAssertEqual(mockValueCache.removeObjectCallCount, 4)
+        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: hashedContextKey, contextHash: hashedContextKey, lastUpdated: later, etag: nil)
+        XCTAssertEqual(mockValueCache.removeObjectCallCount, 6)
         XCTAssertTrue(removedObjects.contains("flags-key1"))
         XCTAssertTrue(removedObjects.contains("etag-key1"))
         XCTAssertTrue(removedObjects.contains("flags-key2"))
@@ -134,13 +169,13 @@ final class FeatureFlagCacheSpec: XCTestCase {
     }
 
     func testStoreInvalidMetadataStored() throws {
-        let hashedContxtKey = Util.sha256base64("context1")
+        let hashedContextKey = Util.sha256base64("context1")
         let now = Date()
         mockValueCache.dataReturnValue = try JSONEncoder().encode(["key1": "123"])
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 1)
-        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: hashedContxtKey, lastUpdated: now, etag: nil)
+        flagCache.saveCachedData(testFlagCollection.flags, cacheKey: hashedContextKey, contextHash: hashedContextKey, lastUpdated: now, etag: nil)
         XCTAssertEqual(mockValueCache.removeObjectCallCount, 0)
         let setMetadata = try JSONDecoder().decode([String: Int64].self, from: mockValueCache.setReceivedArguments!.value)
-        XCTAssertEqual(setMetadata, [hashedContxtKey: now.millisSince1970])
+        XCTAssertEqual(setMetadata, [hashedContextKey: now.millisSince1970])
     }
 }

--- a/LaunchDarkly/LaunchDarklyTests/TestContext.swift
+++ b/LaunchDarkly/LaunchDarklyTests/TestContext.swift
@@ -69,7 +69,10 @@ class TestContext {
             let mobileKey = self.serviceFactoryMock.makeFeatureFlagCacheReceivedParameters!.mobileKey
             let mockCache = FeatureFlagCachingMock()
             mockCache.getCachedDataCallback = {
-                mockCache.getCachedDataReturnValue = (items: StoredItems(items: self.cachedFlags[mobileKey]?[mockCache.getCachedDataReceivedCacheKey!] ?? [:]), etag: nil, lastUpdated: nil)
+                let arguments = mockCache.getCachedDataReceivedArguments
+                let cacheKey = arguments?.cacheKey
+                let flags = cacheKey.map { self.cachedFlags[mobileKey]?[$0] ?? [:] } ?? [:]
+                mockCache.getCachedDataReturnValue = (items: StoredItems(items: flags), etag: nil, lastUpdated: nil)
             }
             self.serviceFactoryMock.makeFeatureFlagCacheReturnValue = mockCache
         }
@@ -81,7 +84,7 @@ class TestContext {
     }
 
     func withCached(flags: [LDFlagKey: FeatureFlag]?) -> TestContext {
-        withCached(contextKey: context.contextHash(), flags: flags)
+        withCached(contextKey: context.fullyQualifiedHashedKey(), flags: flags)
     }
 
     func withCached(contextKey: String, flags: [LDFlagKey: FeatureFlag]?) -> TestContext {


### PR DESCRIPTION
Instead of indexing by the full context's hash, we are going to revert to indexing by canonical key. The cache will store the hash alongside the flag values.

This stored hash will be compared with the active context hash when the cache is read. If the hashes are different, the SDK will fetch updated values. If they haven't changed, then the SDK is free to wait until the cache freshness has exceeded the configured polling interval.

As a result, the SDK should have a smoother transition from

    default -> last known values -> fresh values

as the context changes while also minimizing unnecessary API requests.