### PR TITLE
feat: Adds support for client-side prerequisite events

### DIFF
--- a/ContractTests/Source/Controllers/SdkController.swift
+++ b/ContractTests/Source/Controllers/SdkController.swift
@@ -31,7 +31,8 @@ final class SdkController: RouteCollection {
             "anonymous-redaction",
             "evaluation-hooks",
             "event-gzip",
-            "optional-event-gzip"
+            "optional-event-gzip",
+            "client-prereq-events"
         ]
 
         return StatusResponse(

--- a/LaunchDarkly/GeneratedCode/mocks.generated.swift
+++ b/LaunchDarkly/GeneratedCode/mocks.generated.swift
@@ -214,12 +214,12 @@ final class EventReportingMock: EventReporting {
     }
 
     var recordFlagEvaluationEventsCallCount = 0
-    var recordFlagEvaluationEventsCallback: (() throws -> Void)?
+    var recordFlagEvaluationEventsCallback: ((_ event: FeatureEvent) throws -> Void)?
     var recordFlagEvaluationEventsReceivedArguments: (flagKey: LDFlagKey, value: LDValue, defaultValue: LDValue, featureFlag: FeatureFlag?, context: LDContext, includeReason: Bool)?
     func recordFlagEvaluationEvents(flagKey: LDFlagKey, value: LDValue, defaultValue: LDValue, featureFlag: FeatureFlag?, context: LDContext, includeReason: Bool) {
         recordFlagEvaluationEventsCallCount += 1
         recordFlagEvaluationEventsReceivedArguments = (flagKey: flagKey, value: value, defaultValue: defaultValue, featureFlag: featureFlag, context: context, includeReason: includeReason)
-        try! recordFlagEvaluationEventsCallback?()
+        try! recordFlagEvaluationEventsCallback?(FeatureEvent(key: flagKey, context: context, value: value, defaultValue: defaultValue, featureFlag: featureFlag, includeReason: includeReason, isDebug: false))
     }
 
     var flushCallCount = 0

--- a/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FeatureFlag.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FeatureFlag.swift
@@ -3,7 +3,7 @@ import Foundation
 struct FeatureFlag: Codable {
 
     enum CodingKeys: String, CodingKey, CaseIterable {
-        case flagKey = "key", value, variation, version, flagVersion, trackEvents, debugEventsUntilDate, reason, trackReason
+        case flagKey = "key", value, variation, version, flagVersion, trackEvents, debugEventsUntilDate, reason, trackReason, prerequisites
     }
 
     let flagKey: LDFlagKey
@@ -17,6 +17,7 @@ struct FeatureFlag: Codable {
     let debugEventsUntilDate: Date?
     let reason: [String: LDValue]?
     let trackReason: Bool
+    let prerequisites: [String]?
 
     var versionForEvents: Int? { flagVersion ?? version }
 
@@ -28,7 +29,8 @@ struct FeatureFlag: Codable {
          trackEvents: Bool = false,
          debugEventsUntilDate: Date? = nil,
          reason: [String: LDValue]? = nil,
-         trackReason: Bool = false) {
+         trackReason: Bool = false,
+         prerequisites: [String]? = nil) {
         self.flagKey = flagKey
         self.value = value
         self.variation = variation
@@ -38,6 +40,7 @@ struct FeatureFlag: Codable {
         self.debugEventsUntilDate = debugEventsUntilDate
         self.reason = reason
         self.trackReason = trackReason
+        self.prerequisites = prerequisites
     }
 
     init(from decoder: Decoder) throws {
@@ -61,6 +64,7 @@ struct FeatureFlag: Codable {
         self.debugEventsUntilDate = Date(millisSince1970: try container.decodeIfPresent(Int64.self, forKey: .debugEventsUntilDate))
         self.reason = try container.decodeIfPresent([String: LDValue].self, forKey: .reason)
         self.trackReason = (try container.decodeIfPresent(Bool.self, forKey: .trackReason)) ?? false
+        self.prerequisites = (try container.decodeIfPresent([String].self, forKey: .prerequisites))
     }
 
     func encode(to encoder: Encoder) throws {
@@ -76,6 +80,9 @@ struct FeatureFlag: Codable {
         }
         if reason != nil { try container.encode(reason, forKey: .reason) }
         if trackReason { try container.encode(true, forKey: .trackReason) }
+        if let prerequisites = prerequisites, !prerequisites.isEmpty {
+            try container.encodeIfPresent(prerequisites, forKey: .prerequisites)
+        }
     }
 
     func shouldCreateDebugEvents(lastEventReportResponseTime: Date?) -> Bool {

--- a/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagRequestTracker.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagRequestTracker.swift
@@ -12,11 +12,11 @@ struct FlagRequestTracker {
 
     mutating func trackRequest(flagKey: LDFlagKey, reportedValue: LDValue, featureFlag: FeatureFlag?, defaultValue: LDValue, context: LDContext) {
         if flagCounters[flagKey] == nil {
-            flagCounters[flagKey] = FlagCounter()
+            flagCounters[flagKey] = FlagCounter(defaultValue: defaultValue)
         }
         guard let flagCounter = flagCounters[flagKey]
         else { return }
-        flagCounter.trackRequest(reportedValue: reportedValue, featureFlag: featureFlag, defaultValue: defaultValue, context: context)
+        flagCounter.trackRequest(reportedValue: reportedValue, featureFlag: featureFlag, context: context)
 
         os_log("%s \n\tflagKey: %s\n\treportedValue: %s\n\tvariation: %s\n\tversion: %s\n\tdefaultValue: %s", log: logger, type: .debug,
             typeName(and: #function),
@@ -41,12 +41,16 @@ final class FlagCounter: Encodable {
         case value, variation, version, unknown, count
     }
 
-    private(set) var defaultValue: LDValue = .null
+    private(set) var defaultValue: LDValue
     private(set) var flagValueCounters: [CounterKey: CounterValue] = [:]
     private(set) var contextKinds: Set<String> = Set()
-
-    func trackRequest(reportedValue: LDValue, featureFlag: FeatureFlag?, defaultValue: LDValue, context: LDContext) {
+    
+    init(defaultValue: LDValue) {
+        // default value follows a "first one wins" approach where the first evaluation for a flag key sets the default value for the summary events
         self.defaultValue = defaultValue
+    }
+
+    func trackRequest(reportedValue: LDValue, featureFlag: FeatureFlag?, context: LDContext) {
         let key = CounterKey(variation: featureFlag?.variation, version: featureFlag?.versionForEvents)
         if let counter = flagValueCounters[key] {
             counter.increment()
@@ -61,7 +65,9 @@ final class FlagCounter: Encodable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(defaultValue, forKey: .defaultValue)
+        if defaultValue != .null {
+            try container.encode(defaultValue, forKey: .defaultValue)
+        }
         try container.encode(contextKinds, forKey: .contextKinds)
         var countersContainer = container.nestedUnkeyedContainer(forKey: .counters)
         try flagValueCounters.forEach { (key, value) in

--- a/LaunchDarkly/LaunchDarklyTests/Models/EventSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/EventSpec.swift
@@ -219,9 +219,9 @@ final class EventSpec: XCTestCase {
             XCTAssertEqual(dict["endDate"], .number(Double(event.endDate.millisSince1970)))
             valueIsObject(dict["features"]) { features in
                 XCTAssertEqual(features.count, 1)
-                let counter = FlagCounter()
-                counter.trackRequest(reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
-                counter.trackRequest(reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
+                let counter = FlagCounter(defaultValue: true)
+                counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
+                counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
                 XCTAssertEqual(features["bool-flag"], encodeToLDValue(counter))
             }
         }

--- a/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagCounterSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagCounterSpec.swift
@@ -8,15 +8,15 @@ final class FlagCounterSpec: XCTestCase {
     private let testValue: LDValue = 5.5
 
     func testInit() {
-        let flagCounter = FlagCounter()
-        XCTAssertEqual(flagCounter.defaultValue, .null)
+        let flagCounter = FlagCounter(defaultValue: true)
+        XCTAssertEqual(flagCounter.defaultValue, true)
         XCTAssert(flagCounter.flagValueCounters.isEmpty)
     }
 
     func testTrackRequestInitialKnown() {
         let featureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 2, flagVersion: 3)
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: testDefaultValue)
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, context: LDContext.stub())
         XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
         XCTAssertEqual(flagCounter.flagValueCounters.count, 1)
         let counter = flagCounter.flagValueCounters.first!
@@ -29,10 +29,10 @@ final class FlagCounterSpec: XCTestCase {
     func testTrackRequestKnownMatching() {
         let featureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 5, flagVersion: 3)
         let secondFeatureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 7, flagVersion: 3)
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, defaultValue: "e", context: LDContext.stub())
-        flagCounter.trackRequest(reportedValue: "b", featureFlag: secondFeatureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
-        XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
+        let flagCounter = FlagCounter(defaultValue: "e")
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, context: LDContext.stub())
+        flagCounter.trackRequest(reportedValue: "b", featureFlag: secondFeatureFlag, context: LDContext.stub())
+        XCTAssertEqual(flagCounter.defaultValue, "e")
         XCTAssertEqual(flagCounter.flagValueCounters.count, 1)
         let counter = flagCounter.flagValueCounters.first!
         XCTAssertEqual(counter.key.version, 3)
@@ -44,9 +44,9 @@ final class FlagCounterSpec: XCTestCase {
     func testTrackRequestKnownDifferentVariations() {
         let featureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 10, flagVersion: 5)
         let secondFeatureFlag = FeatureFlag(flagKey: "test-key", variation: 3, version: 10, flagVersion: 5)
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: secondFeatureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: testDefaultValue)
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, context: LDContext.stub())
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: secondFeatureFlag, context: LDContext.stub())
         XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
         XCTAssertEqual(flagCounter.flagValueCounters.count, 2)
         let counter1 = flagCounter.flagValueCounters.first { key, _ in key.variation == 2 }!
@@ -62,9 +62,9 @@ final class FlagCounterSpec: XCTestCase {
     func testTrackRequestKnownDifferentFlagVersions() {
         let featureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 10, flagVersion: 3)
         let secondFeatureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 10, flagVersion: 5)
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: secondFeatureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: testDefaultValue)
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, context: LDContext.stub())
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: secondFeatureFlag, context: LDContext.stub())
         XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
         XCTAssertEqual(flagCounter.flagValueCounters.count, 2)
         let counter1 = flagCounter.flagValueCounters.first { key, _ in key.version == 3 }!
@@ -80,9 +80,9 @@ final class FlagCounterSpec: XCTestCase {
     func testTrackRequestKnownMissingFlagVersionMatchingVersions() {
         let featureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 10)
         let secondFeatureFlag = FeatureFlag(flagKey: "test-key", variation: 2, version: 5, flagVersion: 10)
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: secondFeatureFlag, defaultValue: testDefaultValue, context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: testDefaultValue)
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: featureFlag, context: LDContext.stub())
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: secondFeatureFlag, context: LDContext.stub())
         XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
         XCTAssertEqual(flagCounter.flagValueCounters.count, 1)
         let counter = flagCounter.flagValueCounters.first!
@@ -93,8 +93,8 @@ final class FlagCounterSpec: XCTestCase {
     }
 
     func testTrackRequestInitialUnknown() {
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: nil, defaultValue: testDefaultValue, context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: testDefaultValue)
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: nil, context: LDContext.stub())
         XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
         XCTAssertEqual(flagCounter.flagValueCounters.count, 1)
         let counter = flagCounter.flagValueCounters.first!
@@ -105,9 +105,9 @@ final class FlagCounterSpec: XCTestCase {
     }
 
     func testTrackRequestSecondUnknown() {
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: nil, defaultValue: testDefaultValue, context: LDContext.stub())
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: nil, defaultValue: testDefaultValue, context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: testDefaultValue)
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: nil, context: LDContext.stub())
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: nil, context: LDContext.stub())
         XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
         XCTAssertEqual(flagCounter.flagValueCounters.count, 1)
         let counter = flagCounter.flagValueCounters.first!
@@ -120,9 +120,9 @@ final class FlagCounterSpec: XCTestCase {
     func testTrackRequestSecondUnknownWithDifferentVariations() {
         let unknownFlag1 = FeatureFlag(flagKey: "unused", variation: 1)
         let unknownFlag2 = FeatureFlag(flagKey: "unused", variation: 2)
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: unknownFlag1, defaultValue: testDefaultValue, context: LDContext.stub())
-        flagCounter.trackRequest(reportedValue: testValue, featureFlag: unknownFlag2, defaultValue: testDefaultValue, context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: testDefaultValue)
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: unknownFlag1, context: LDContext.stub())
+        flagCounter.trackRequest(reportedValue: testValue, featureFlag: unknownFlag2, context: LDContext.stub())
         XCTAssertEqual(flagCounter.defaultValue, testDefaultValue)
         XCTAssertEqual(flagCounter.flagValueCounters.count, 2)
         let counter1 = flagCounter.flagValueCounters.first { key, _ in key.variation == 1 }!
@@ -139,9 +139,9 @@ final class FlagCounterSpec: XCTestCase {
 
     func testEncoding() {
         let featureFlag = FeatureFlag(flagKey: "unused", variation: 3, version: 2, flagVersion: 5)
-        let flagCounter = FlagCounter()
-        flagCounter.trackRequest(reportedValue: "a", featureFlag: featureFlag, defaultValue: "b", context: LDContext.stub())
-        flagCounter.trackRequest(reportedValue: "a", featureFlag: featureFlag, defaultValue: "b", context: LDContext.stub())
+        let flagCounter = FlagCounter(defaultValue: "b")
+        flagCounter.trackRequest(reportedValue: "a", featureFlag: featureFlag, context: LDContext.stub())
+        flagCounter.trackRequest(reportedValue: "a", featureFlag: featureFlag, context: LDContext.stub())
         encodesToObject(flagCounter) { dict in
             XCTAssertEqual(dict.count, 3)
             XCTAssertEqual(dict["default"], "b")
@@ -158,11 +158,11 @@ final class FlagCounterSpec: XCTestCase {
             }
         }
 
-        let flagCounterNulls = FlagCounter()
-        flagCounterNulls.trackRequest(reportedValue: nil, featureFlag: nil, defaultValue: nil, context: LDContext.stub())
+        let flagCounterNulls = FlagCounter(defaultValue: nil)
+        flagCounterNulls.trackRequest(reportedValue: nil, featureFlag: nil, context: LDContext.stub())
         encodesToObject(flagCounterNulls) { dict in
-            XCTAssertEqual(dict.count, 3)
-            XCTAssertEqual(dict["default"], .null)
+            XCTAssertEqual(dict.count, 2)
+            XCTAssertEqual(dict["default"], nil)
             XCTAssertEqual(dict["contextKinds"], ["user"])
             valueIsArray(dict["counters"]) { counters in
                 XCTAssertEqual(counters.count, 1)
@@ -183,19 +183,20 @@ extension FlagCounter {
     }
 
     class func stub(flagKey: LDFlagKey) -> FlagCounter {
-        let flagCounter = FlagCounter()
         var featureFlag: FeatureFlag? = nil
         if flagKey.isKnown {
             featureFlag = DarklyServiceMock.Constants.stubFeatureFlag(for: flagKey)
+            let flagCounter = FlagCounter(defaultValue: featureFlag?.value ?? .null)
             for _ in 0..<Constants.requestCount {
-                flagCounter.trackRequest(reportedValue: featureFlag?.value ?? .null, featureFlag: featureFlag, defaultValue: featureFlag?.value ?? .null, context: LDContext.stub())
+                flagCounter.trackRequest(reportedValue: featureFlag?.value ?? .null, featureFlag: featureFlag, context: LDContext.stub())
             }
+            return flagCounter
         } else {
+            let flagCounter = FlagCounter(defaultValue: false)
             for _ in 0..<Constants.requestCount {
-                flagCounter.trackRequest(reportedValue: false, featureFlag: nil, defaultValue: false, context: LDContext.stub())
+                flagCounter.trackRequest(reportedValue: false, featureFlag: nil, context: LDContext.stub())
             }
+            return flagCounter
         }
-
-        return flagCounter
     }
 }

--- a/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagRequestTrackerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagRequestTrackerSpec.swift
@@ -57,7 +57,7 @@ final class FlagRequestTrackerSpec: XCTestCase {
         XCTAssertEqual(flagRequestTracker.flagCounters.count, 2)
         let counter1 = FlagCounter(defaultValue: true)
         counter1.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
-        let counter2 = FlagCounter(defaultValue: true)
+        let counter2 = FlagCounter(defaultValue: false)
         counter2.trackRequest(reportedValue: true, featureFlag: secondFlag, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters["bool-flag"], counter1)
         XCTAssertEqual(flagRequestTracker.flagCounters["alt-flag"], counter2)

--- a/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagRequestTrackerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagRequestTrackerSpec.swift
@@ -19,8 +19,8 @@ final class FlagRequestTrackerSpec: XCTestCase {
         var flagRequestTracker = FlagRequestTracker(logger: OSLog(subsystem: "com.launchdarkly", category: "tests"))
         flagRequestTracker.trackRequest(flagKey: "bool-flag", reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters.count, 1)
-        let counter = FlagCounter()
-        counter.trackRequest(reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
+        let counter = FlagCounter(defaultValue: true)
+        counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters["bool-flag"], counter)
     }
 
@@ -30,9 +30,21 @@ final class FlagRequestTrackerSpec: XCTestCase {
         flagRequestTracker.trackRequest(flagKey: "bool-flag", reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
         flagRequestTracker.trackRequest(flagKey: "bool-flag", reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters.count, 1)
-        let counter = FlagCounter()
-        counter.trackRequest(reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
-        counter.trackRequest(reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
+        let counter = FlagCounter(defaultValue: true)
+        counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
+        counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
+        XCTAssertEqual(flagRequestTracker.flagCounters["bool-flag"], counter)
+    }
+    
+    func testTrackRequestSameFlagKeyDifferentDefault() {
+        let flag = FeatureFlag(flagKey: "bool-flag", variation: 1, version: 5, flagVersion: 2)
+        var flagRequestTracker = FlagRequestTracker(logger: OSLog(subsystem: "com.launchdarkly", category: "tests"))
+        flagRequestTracker.trackRequest(flagKey: "bool-flag", reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
+        flagRequestTracker.trackRequest(flagKey: "bool-flag", reportedValue: false, featureFlag: flag, defaultValue: false, context: LDContext.stub())
+        XCTAssertEqual(flagRequestTracker.flagCounters.count, 1)
+        let counter = FlagCounter(defaultValue: true)
+        counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
+        counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters["bool-flag"], counter)
     }
 
@@ -43,10 +55,10 @@ final class FlagRequestTrackerSpec: XCTestCase {
         flagRequestTracker.trackRequest(flagKey: "bool-flag", reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
         flagRequestTracker.trackRequest(flagKey: "alt-flag", reportedValue: true, featureFlag: secondFlag, defaultValue: false, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters.count, 2)
-        let counter1 = FlagCounter()
-        counter1.trackRequest(reportedValue: false, featureFlag: flag, defaultValue: true, context: LDContext.stub())
-        let counter2 = FlagCounter()
-        counter2.trackRequest(reportedValue: true, featureFlag: secondFlag, defaultValue: false, context: LDContext.stub())
+        let counter1 = FlagCounter(defaultValue: true)
+        counter1.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
+        let counter2 = FlagCounter(defaultValue: true)
+        counter2.trackRequest(reportedValue: true, featureFlag: secondFlag, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters["bool-flag"], counter1)
         XCTAssertEqual(flagRequestTracker.flagCounters["alt-flag"], counter2)
     }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v9/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

SDK-684

**Describe the solution you've provided**

Added prerequisites to flag model
Variation calls now recurse on prerequisites
Updated iOS FlagRequestTracker to use "first default wins" instead of "last default wins" to be more consistent with other SDK implementations.  Also updated it to not serialize a null default.
