### PR TITLE
chore: Install correct mint binary

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -27,8 +27,7 @@ runs:
     - name: Install mint
       shell: bash
       run: |
-        brew tap mint-lang/mint-lang
-        brew install mint-lang libressl
+        brew install mint
 
     - name: Install cocoapods
       shell: bash

--- a/LaunchDarkly/LaunchDarkly/LDClientVariation.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClientVariation.swift
@@ -177,7 +177,7 @@ extension LDClient {
                     // recurse on prerequisites to emulate prereq evaluations occurring with desirable side effects such as events for prereqs
                     _ = variationDetailInternal(prereqFlagKey, LDValue.null, needsReason: needsReason, methodName: methodName)
                 }
-                
+
                 if featureFlag.value == .null {
                     result = LDEvaluationDetail(value: defaultValue, variationIndex: featureFlag.variation, reason: featureFlag.reason)
                 } else {
@@ -193,7 +193,7 @@ extension LDClient {
                 os_log("%s Unknown feature flag %s; returning default value", log: config.logger, type: .debug, typeName(and: #function), flagKey.description)
                 result = LDEvaluationDetail(value: defaultValue, variationIndex: nil, reason: ["kind": "ERROR", "errorKind": "FLAG_NOT_FOUND"])
             }
-            
+
             eventReporter.recordFlagEvaluationEvents(flagKey: flagKey,
                                                      value: result.value.toLDValue(),
                                                      defaultValue: defaultValue.toLDValue(),

--- a/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagRequestTracker.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagRequestTracker.swift
@@ -44,7 +44,7 @@ final class FlagCounter: Encodable {
     private(set) var defaultValue: LDValue
     private(set) var flagValueCounters: [CounterKey: CounterValue] = [:]
     private(set) var contextKinds: Set<String> = Set()
-    
+
     init(defaultValue: LDValue) {
         // default value follows a "first one wins" approach where the first evaluation for a flag key sets the default value for the summary events
         self.defaultValue = defaultValue

--- a/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagRequestTrackerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/FeatureFlag/FlagRequestTracking/FlagRequestTrackerSpec.swift
@@ -35,7 +35,7 @@ final class FlagRequestTrackerSpec: XCTestCase {
         counter.trackRequest(reportedValue: false, featureFlag: flag, context: LDContext.stub())
         XCTAssertEqual(flagRequestTracker.flagCounters["bool-flag"], counter)
     }
-    
+
     func testTrackRequestSameFlagKeyDifferentDefault() {
         let flag = FeatureFlag(flagKey: "bool-flag", variation: 1, version: 5, flagVersion: 2)
         var flagRequestTracker = FlagRequestTracker(logger: OSLog(subsystem: "com.launchdarkly", category: "tests"))


### PR DESCRIPTION
This repository makes use of [mint][1] to run swift-based binaries.
Unfortunately, we were erroneously installing [mint-lang][2].

This means our CI has been failing to run our swift lint checker. As a
result, I have fixed the critical issues in this commit as well.

[1]: https://github.com/yonaskolb/Mint
[2]: https://mint-lang.com/