### PR TITLE
fix: replaced inefficient string logic for sync complete log

### DIFF
--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -621,9 +621,9 @@ public class LDClient {
     }
 
     private func onFlagSyncComplete(result: FlagSyncResult) {
-        os_log("%s result: %s", log: config.logger, type: .debug, typeName(and: #function), String(describing: result))
         switch result {
         case let .flagCollection((flagCollection, etag)):
+            os_log("%s: got flag collection with %d flags.", log: config.logger, type: .debug, typeName(and: #function), flagCollection.flags.count)
             let oldStoredItems = flagStore.storedItems
             connectionInformation = ConnectionInformation.checkEstablishingStreaming(connectionInformation: connectionInformation)
             flagStore.replaceStore(newStoredItems: StoredItems(items: flagCollection.flags))

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -498,7 +498,7 @@ public class LDClient {
      - parameter handler: The closure the SDK will execute when the feature flag changes.
     */
     public func observe(key: LDFlagKey, owner: LDObserverOwner, handler: @escaping LDFlagChangeHandler) {
-        os_log("%s flagKey: %s owner: %s", log: config.logger, type: .debug, typeName(and: #function), key, String(describing: owner))
+        os_log("%s called for flagKey: %s", log: config.logger, type: .debug, typeName(and: #function), key)
         flagChangeNotifier.addFlagChangeObserver(FlagChangeObserver(key: key, owner: owner, flagChangeHandler: handler))
     }
 
@@ -526,7 +526,7 @@ public class LDClient {
      - parameter handler: The LDFlagCollectionChangeHandler the SDK will execute 1 time when any of the observed feature flags change.
      */
     public func observe(keys: [LDFlagKey], owner: LDObserverOwner, handler: @escaping LDFlagCollectionChangeHandler) {
-        os_log("%s flagKeys: %s owner: %s", log: config.logger, type: .debug, typeName(and: #function), String(describing: keys), String(describing: owner))
+        os_log("%s called for flagKeys: %s", log: config.logger, type: .debug, typeName(and: #function), String(describing: keys))
         flagChangeNotifier.addFlagChangeObserver(FlagChangeObserver(keys: keys, owner: owner, flagCollectionChangeHandler: handler))
     }
 
@@ -553,7 +553,7 @@ public class LDClient {
      - parameter handler: The LDFlagCollectionChangeHandler the SDK will execute 1 time when any of the observed feature flags change.
      */
     public func observeAll(owner: LDObserverOwner, handler: @escaping LDFlagCollectionChangeHandler) {
-        os_log("%s owner: %s", log: config.logger, type: .debug, typeName(and: #function), String(describing: owner))
+        os_log("%s called.", log: config.logger, type: .debug, typeName(and: #function))
         flagChangeNotifier.addFlagChangeObserver(FlagChangeObserver(keys: LDFlagKey.anyKey, owner: owner, flagCollectionChangeHandler: handler))
     }
 

--- a/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagRequestTracker.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagRequestTracker.swift
@@ -18,13 +18,11 @@ struct FlagRequestTracker {
         else { return }
         flagCounter.trackRequest(reportedValue: reportedValue, featureFlag: featureFlag, context: context)
 
-        os_log("%s \n\tflagKey: %s\n\treportedValue: %s\n\tvariation: %s\n\tversion: %s\n\tdefaultValue: %s", log: logger, type: .debug,
+        os_log("%s \n\tflagKey: %s\n\tvariation: %s\n\tversion: %s", log: logger, type: .debug,
             typeName(and: #function),
             flagKey,
-            String(describing: reportedValue),
             String(describing: featureFlag?.variation),
-            String(describing: featureFlag?.flagVersion ?? featureFlag?.version),
-            String(describing: defaultValue))
+            String(describing: featureFlag?.flagVersion ?? featureFlag?.version))
     }
 
     var hasLoggedRequests: Bool { !flagCounters.isEmpty }

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagChangeNotifier.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagChangeNotifier.swift
@@ -27,23 +27,23 @@ final class FlagChangeNotifier: FlagChangeNotifying {
     }
 
     func addFlagChangeObserver(_ observer: FlagChangeObserver) {
-        os_log("%s observer: %s", log: logger, type: .debug, typeName(and: #function), String(describing: observer))
+        os_log("%s called for keys %s", log: logger, type: .debug, typeName(and: #function), String(describing: observer.flagKeys))
         flagChangeQueue.sync { flagChangeObservers.append(observer) }
     }
 
     func addFlagsUnchangedObserver(_ observer: FlagsUnchangedObserver) {
-        os_log("%s observer: %s", log: logger, type: .debug, typeName(and: #function), String(describing: observer))
+        os_log("%s called.", log: logger, type: .debug, typeName(and: #function), String(describing: observer))
         flagsUnchangedQueue.sync { flagsUnchangedObservers.append(observer) }
     }
 
     func addConnectionModeChangedObserver(_ observer: ConnectionModeChangedObserver) {
-        os_log("%s observer: %s", log: logger, type: .debug, typeName(and: #function), String(describing: observer))
+        os_log("%s called.", log: logger, type: .debug, typeName(and: #function))
         connectionModeChangedQueue.sync { connectionModeChangedObservers.append(observer) }
     }
 
     /// Removes all change handling closures from owner
     func removeObserver(owner: LDObserverOwner) {
-        os_log("%s owner: %s", log: logger, type: .debug, typeName(and: #function), String(describing: owner))
+        os_log("%s called.", log: logger, type: .debug, typeName(and: #function))
         flagChangeQueue.sync { flagChangeObservers.removeAll { $0.owner === owner } }
         flagsUnchangedQueue.sync { flagsUnchangedObservers.removeAll { $0.owner === owner } }
         connectionModeChangedQueue.sync { connectionModeChangedObservers.removeAll { $0.owner === owner } }

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagChangeNotifier.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagChangeNotifier.swift
@@ -32,7 +32,7 @@ final class FlagChangeNotifier: FlagChangeNotifying {
     }
 
     func addFlagsUnchangedObserver(_ observer: FlagsUnchangedObserver) {
-        os_log("%s called.", log: logger, type: .debug, typeName(and: #function), String(describing: observer))
+        os_log("%s called.", log: logger, type: .debug, typeName(and: #function))
         flagsUnchangedQueue.sync { flagsUnchangedObservers.append(observer) }
     }
 

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagStore.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagStore.swift
@@ -89,11 +89,11 @@ final class FlagStore: FlagMaintaining {
     init(logger: OSLog, storedItems: StoredItems) {
         self.logger = logger
         self._storedItems = storedItems
-        os_log("%s storedItems:", log: logger, type: .debug, typeName(and: #function), String(describing: storedItems))
+        os_log("%s with %d items", log: logger, type: .debug, typeName(and: #function), storedItems.count)
     }
 
     func replaceStore(newStoredItems: StoredItems) {
-        os_log("%s newFlags: ", log: logger, type: .debug, typeName(and: #function), String(describing: newStoredItems))
+        os_log("%s replacing %d items", log: logger, type: .debug, typeName(and: #function), newStoredItems.count)
         flagQueue.sync(flags: .barrier) {
             self._storedItems = newStoredItems
         }
@@ -107,7 +107,7 @@ final class FlagStore: FlagMaintaining {
                 return
             }
 
-            os_log("%s succeeded. new flag: %s prior flag: %s", log: logger, type: .debug, typeName(and: #function), String(describing: updatedFlag), String(describing: self._storedItems[updatedFlag.flagKey]))
+            os_log("%s updated flag %s", log: logger, type: .debug, typeName(and: #function), updatedFlag.flagKey)
             self._storedItems.updateValue(StorageItem.item(updatedFlag), forKey: updatedFlag.flagKey)
         }
     }
@@ -120,7 +120,7 @@ final class FlagStore: FlagMaintaining {
                 return
             }
 
-            os_log("%s deleted flag with key: %s", log: logger, type: .debug, typeName(and: #function), deleteResponse.key)
+            os_log("%s deleted flag %s", log: logger, type: .debug, typeName(and: #function), deleteResponse.key)
             self._storedItems.updateValue(StorageItem.tombstone(deleteResponse.version ?? 0), forKey: deleteResponse.key)
         }
     }


### PR DESCRIPTION
**Additional context**
String creation of flag collection was happening regardless of logging level.  This fix resolves the performance issue in a straightforward way while maintaining enough information to verify SDK is receiving flag data when debugging.