### PR TITLE
refactor: Adress a couple of warnings - `private(set)` with a space

### DIFF
--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/EventReporter.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/EventReporter.swift
@@ -36,7 +36,7 @@ class EventReporter: EventReporting {
         set { timerQueue.sync { newValue ? startReporting() : stopReporting() } }
     }
 
-    private (set) var lastEventResponseDate: Date
+    private(set) var lastEventResponseDate: Date
 
     let service: DarklyServiceProvider
 

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagChangeNotifier.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/FlagChangeNotifier.swift
@@ -14,9 +14,9 @@ protocol FlagChangeNotifying {
 
 final class FlagChangeNotifier: FlagChangeNotifying {
     // Exposed for testing
-    private (set) var flagChangeObservers = [FlagChangeObserver]()
-    private (set) var flagsUnchangedObservers = [FlagsUnchangedObserver]()
-    private (set) var connectionModeChangedObservers = [ConnectionModeChangedObserver]()
+    private(set) var flagChangeObservers = [FlagChangeObserver]()
+    private(set) var flagsUnchangedObservers = [FlagsUnchangedObserver]()
+    private(set) var connectionModeChangedObservers = [ConnectionModeChangedObserver]()
     private var flagChangeQueue = DispatchQueue(label: "com.launchdarkly.FlagChangeNotifier.FlagChangeQueue")
     private var flagsUnchangedQueue = DispatchQueue(label: "com.launchdarkly.FlagChangeNotifier.FlagsUnchangedQueue")
     private var connectionModeChangedQueue = DispatchQueue(label: "com.launchdarkly.FlagChangeNotifier.ConnectionModeChangedQueue")

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/LDTimer.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/LDTimer.swift
@@ -9,10 +9,10 @@ protocol TimeResponding {
 
 final class LDTimer: TimeResponding {
 
-    private (set) weak var timer: Timer?
+    private(set) weak var timer: Timer?
     private let fireQueue: DispatchQueue
     private let execute: () -> Void
-    private (set) var isCancelled: Bool = false
+    private(set) var isCancelled: Bool = false
     var fireDate: Date? { timer?.fireDate }
 
     init(withTimeInterval timeInterval: TimeInterval, fireQueue: DispatchQueue = DispatchQueue.main, fireAt: Date? = nil, execute: @escaping () -> Void) {

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/Throttler.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/Throttler.swift
@@ -22,8 +22,8 @@ final class Throttler: Throttling {
     let maxDelay: TimeInterval
     private let logger: OSLog
 
-    private (set) var runAttempts = -1
-    private (set) var workItem: DispatchWorkItem?
+    private(set) var runAttempts = -1
+    private(set) var workItem: DispatchWorkItem?
 
     init(
         logger: OSLog,


### PR DESCRIPTION
## 🖼️ 

<img width="773" alt="Screenshot 2025-06-18 at 8 28 59" src="https://github.com/user-attachments/assets/5092b8e1-366b-495c-af95-9f953460c523" />

## ⚠️ 

```
Extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode
```