### PR TITLE
chore: Remove unused `syncResult`

### DIFF
--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
@@ -853,7 +853,6 @@ final class FlagSynchronizerSpec: QuickSpec {
     }
 
     func pollingTimerFiresSpec() {
-        var syncResult: FlagSyncResult?
         describe("polling timer fires") {
             var testContext: TestContext!
 


### PR DESCRIPTION
## 🖼️ 

<img width="743" alt="Screenshot 2025-06-18 at 8 44 18" src="https://github.com/user-attachments/assets/4411dfcf-395d-4e89-9076-511a68fc77c2" />
