### PR TITLE
feat: allow any type instead encodable in evaluation series data

### DIFF
--- a/ContractTests/Source/Models/hook.swift
+++ b/ContractTests/Source/Models/hook.swift
@@ -96,7 +96,10 @@ struct EvaluationPayload: Encodable {
 
         var nested = container.nestedContainer(keyedBy: DynamicKey.self, forKey: .evaluationSeriesData)
         try evaluationSeriesData.forEach { (_, _) in
-            try evaluationSeriesData.forEach { try nested.encode($1, forKey: DynamicKey(stringValue: $0)!) }
+            for (key, value) in evaluationSeriesData {
+                guard let encodable = value as? Encodable, let dynamicKey = DynamicKey(stringValue: key) else { continue }
+                try nested.encode(encodable, forKey: dynamicKey)
+            }
         }
     }
 }

--- a/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Implementation specific hook data for evaluation stages.
 ///
 /// Hook implementations can use this to store data needed between stages.
-public typealias EvaluationSeriesData = [String: Encodable]
+public typealias EvaluationSeriesData = [String: Any]
 
 /// Protocol for extending SDK functionality via hooks.
 public protocol Hook {


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v9/CONTRIBUTING.md#submitting-pull-requests)
- [ X ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Requirement for EvaluationSeriesData changed from Encodable to Any since it doesn't need serialization.

**Describe alternatives you've considered**

No other alternative considered since EvaluationSeriesData is not serializable.

**Additional context**

Needed by Observability plugin for swift.
