### PR TITLE
chore!: Bump swift-tools-version to 5.5 and macosx to 12.00 to be compatible with Otel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly iOS SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+### Features
+* bumping swift-tools-version:5.5 and macosx to be compatible with otel
+- masOS "10.13" -> "12.00"
+
 ## [9.16.0](https://github.com/launchdarkly/ios-client-sdk/compare/9.15.0...9.16.0) (2025-09-11)
 
 

--- a/LaunchDarkly.podspec
+++ b/LaunchDarkly.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |ld|
   ld.ios.deployment_target     = "13.0"
   ld.watchos.deployment_target = "6.0"
   ld.tvos.deployment_target    = "13.0"
-  ld.osx.deployment_target     = "10.15"
+  ld.osx.deployment_target     = "12.0"
 
   ld.source       = { :git => ld.homepage + '.git', :tag => ld.version}
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -6,7 +6,7 @@ let package = Package(
     name: "LaunchDarkly",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15),
+        .macOS(.v12),
         .watchOS(.v6),
         .tvOS(.v13)
     ],

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ And supports the following device platforms:
 | iOS      | 13.0    |
 | watchOS  | 6.0     |
 | tvOS     | 13.0    |
-| macOS    | 10.15   |
+| macOS    | 12.00   |
 
 Installation
 -----------


### PR DESCRIPTION
**Requirements**

* bumping swift-tools-version:5.5 and macosx to be compatible with Otel
- masOS "10.13" -> "12.00"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises Swift tools to 5.5 and bumps minimum macOS version to 12.0 across SPM, CocoaPods, and docs.
> 
> - **Build/Platform support**:
>   - Update `Package.swift` to `swift-tools-version:5.5` and `.macOS(.v12)`.
>   - Update `LaunchDarkly.podspec` `ld.osx.deployment_target` to `"12.0"`.
> - **Docs**:
>   - Update `README.md` supported macOS version to `12.00`.
>   - Add `CHANGELOG.md` entry noting Swift tools 5.5 and macOS 12 bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c340dee41aab5331e671703aaa35529f7c15685. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->