### PR TITLE
fix: Flake unit tests

### DIFF
--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ThrottlerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ThrottlerSpec.swift
@@ -165,7 +165,6 @@ final class ThrottlerSpec: QuickSpec {
                 hasRun = true
             }
             throttler.cancelThrottledRun()
-            expect(throttler.safeRunAttempts) == 2
             expect(throttler.workItem).to(beNil())
             // Wait until run would have occured
             Thread.sleep(forTimeInterval: 1.0)

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ThrottlerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ThrottlerSpec.swift
@@ -105,7 +105,6 @@ final class ThrottlerSpec: QuickSpec {
             // First two run immediate
             throttler.runThrottled { }
             throttler.runThrottled { }
-            expect(throttler.safeRunAttempts) == 1
             let callDate = Date()
             var runDate: Date?
             waitUntil(timeout: .seconds(3)) { done in


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v9/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Fix flake unit tests of Throttler

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises minimum platform versions and introduces `TimeoutExecutor`, used by `LDClient.identify` and `LDClient.start` for single-fire timeouts; updates tests and docs accordingly.
> 
> - **Core SDK**:
>   - Add `ServiceObjects/TimeoutExecutor.swift` and use it in `LDClient.identify(..., timeout:)` and `LDClient.start(..., startWaitSeconds:)` to ensure single, deterministic timeout completions.
> - **Tests**:
>   - Add `TimeoutExecutorSpec` and wire into Xcode project.
>   - Tweak `ThrottlerSpec` to remove flaky expectations.
> - **Build/Platforms**:
>   - Bump Swift tools to `5.5` (`Package.swift`).
>   - Raise deployment targets: `iOS 13`, `watchOS 6`, `tvOS 13`, `macOS 12` (SPM, CocoaPods, Xcode project settings).
> - **Docs**:
>   - Update `CHANGELOG.md` and `README.md` to reflect new platform minimums and toolchain version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94866d87d64fa02d6721777477e589b333c7a30f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->