### PR TITLE
chore: update runs-on from macos-13 to macos-14. macos-13 was retired…

### DIFF
--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -4,7 +4,7 @@ on:
 name: Publish Documentation
 jobs:
   build-publish:
-    runs-on: macos-13
+    runs-on: macos-14
 
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-publish:
-    runs-on: macos-13
+    runs-on: macos-14
 
     # Needed to get tokens during publishing.
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-package:
-    runs-on: macos-13
+    runs-on: macos-14
 
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.


### PR DESCRIPTION
- update runs-on from macos-13 to macos-14. macos-13 was retired on December 4

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v9/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Additional context**

[Notification about retirement](https://github.com/actions/runner-images/issues/13046)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update all affected GitHub Actions workflows to run on macos-14 instead of macos-13.
> 
> - **Workflows**:
>   - Update `runs-on` to `macos-14` in:
>     - `.github/workflows/manual-publish-docs.yml`
>     - `.github/workflows/manual-publish.yml`
>     - `.github/workflows/release-please.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f39aa92a75ff773de20babca832db4c7c1dba42b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->