### PR TITLE
feat!: put public completions into main-thread (makes it Swift6 compatible)

### DIFF
--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -115,9 +115,10 @@ public class LDClient {
                 instance.internalSetOnline(goOnline, completion: dispatch.leave)
             }
         }
-        
-        dispatch.notify(queue: .main) {
-            completion?()
+        if let completion {
+            dispatch.notify(queue: .main) {
+                completion()
+            }
         }
     }
 

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -116,12 +116,8 @@ public class LDClient {
             }
         }
         
-        if let completion {
-            dispatch.notify(queue: DispatchQueue.global()) {
-                DispatchQueue.main.async {
-                    completion()
-                }
-            }
+        dispatch.notify(queue: .main) {
+            completion?()
         }
     }
 
@@ -295,9 +291,11 @@ public class LDClient {
     */
     @available(*, deprecated, message: "Use LDClient.identify(context: completion:) with non-optional completion parameter")
     public func identify(context: LDContext, completion: (() -> Void)? = nil) {
-        _identifyMain(context: context, sheddable: false, useCache: .yes, timeout: 0) { _ in
+        _identifyHooked(context: context, sheddable: false, useCache: .yes, timeout: 0) { _ in
             if let completion = completion {
-                completion()
+                DispatchQueue.main.async {
+                    completion()
+                }
             }
         }
     }
@@ -318,7 +316,11 @@ public class LDClient {
      - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
      */
     public func identify(context: LDContext, completion: @escaping (_ result: IdentifyResult) -> Void) {
-        _identifyMain(context: context, sheddable: true, useCache: .yes, timeout: 0, completion: completion)
+        _identifyHooked(context: context, sheddable: true, useCache: .yes, timeout: 0) { result in
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
     }
 
     /**
@@ -332,11 +334,7 @@ public class LDClient {
      - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
      */
     public func identify(context: LDContext, useCache: IdentifyCacheUsage, completion: @escaping (_ result: IdentifyResult) -> Void) {
-        _identifyMain(context: context, sheddable: true, useCache: useCache, timeout: 0, completion: completion)
-    }
-    
-    private func _identifyMain(context: LDContext, sheddable: Bool, useCache: IdentifyCacheUsage, timeout: TimeInterval, completion: @escaping (_ result: IdentifyResult) -> Void) {
-        _identifyHooked(context: context, sheddable: sheddable, useCache: useCache, timeout: timeout) { result in
+        _identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: 0) { result in
             DispatchQueue.main.async {
                 completion(result)
             }
@@ -398,7 +396,11 @@ public class LDClient {
             os_log("%s LDClient.identify was called with a timeout greater than %f seconds. We recommend a timeout of less than %f seconds.", log: config.logger, type: .info, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
         }
         
-        self._identifyMain(context: context, sheddable: true, useCache: useCache, timeout: timeout, completion: completion)
+        self._identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: timeout) { result in
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
     }
 
     func internalIdentify(newContext: LDContext, useCache: IdentifyCacheUsage, completion: (() -> Void)? = nil) {

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -115,8 +115,13 @@ public class LDClient {
                 instance.internalSetOnline(goOnline, completion: dispatch.leave)
             }
         }
-        if let completion = completion {
-            dispatch.notify(queue: DispatchQueue.global(), execute: completion)
+        
+        if let completion {
+            dispatch.notify(queue: DispatchQueue.global()) {
+                DispatchQueue.main.async {
+                    completion()
+                }
+            }
         }
     }
 
@@ -290,7 +295,7 @@ public class LDClient {
     */
     @available(*, deprecated, message: "Use LDClient.identify(context: completion:) with non-optional completion parameter")
     public func identify(context: LDContext, completion: (() -> Void)? = nil) {
-        _identifyHooked(context: context, sheddable: false, useCache: .yes, timeout: 0) { _ in
+        _identifyMain(context: context, sheddable: false, useCache: .yes, timeout: 0) { _ in
             if let completion = completion {
                 completion()
             }
@@ -313,7 +318,7 @@ public class LDClient {
      - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
      */
     public func identify(context: LDContext, completion: @escaping (_ result: IdentifyResult) -> Void) {
-        _identifyHooked(context: context, sheddable: true, useCache: .yes, timeout: 0, completion: completion)
+        _identifyMain(context: context, sheddable: true, useCache: .yes, timeout: 0, completion: completion)
     }
 
     /**
@@ -327,7 +332,15 @@ public class LDClient {
      - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
      */
     public func identify(context: LDContext, useCache: IdentifyCacheUsage, completion: @escaping (_ result: IdentifyResult) -> Void) {
-        _identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: 0, completion: completion)
+        _identifyMain(context: context, sheddable: true, useCache: useCache, timeout: 0, completion: completion)
+    }
+    
+    private func _identifyMain(context: LDContext, sheddable: Bool, useCache: IdentifyCacheUsage, timeout: TimeInterval, completion: @escaping (_ result: IdentifyResult) -> Void) {
+        _identifyHooked(context: context, sheddable: sheddable, useCache: useCache, timeout: timeout) { result in
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
     }
 
     // Temporary helper method to allow code sharing between the sheddable and unsheddable identify methods. In the next major release, we will remove the deprecated identify method and inline
@@ -385,7 +398,7 @@ public class LDClient {
             os_log("%s LDClient.identify was called with a timeout greater than %f seconds. We recommend a timeout of less than %f seconds.", log: config.logger, type: .info, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
         }
         
-        self._identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: timeout, completion: completion)
+        self._identifyMain(context: context, sheddable: true, useCache: useCache, timeout: timeout, completion: completion)
     }
 
     func internalIdentify(newContext: LDContext, useCache: IdentifyCacheUsage, completion: (() -> Void)? = nil) {
@@ -741,7 +754,13 @@ public class LDClient {
     /// - Tag: start
     @available(*, deprecated, message: "Use LDClient.start(config: context: startWithSeconds: completion:) to initialize the SDK with a defined timeout")
     public static func start(config: LDConfig, context: LDContext? = nil, completion: (() -> Void)? = nil) {
-        start(serviceFactory: nil, config: config, context: context, completion: completion)
+        start(serviceFactory: nil, config: config, context: context) {
+            if let completion {
+                DispatchQueue.main.async {
+                    completion()
+                }
+            }
+        }
     }
 
     static func start(serviceFactory: ClientServiceCreating?, config: LDConfig, context: LDContext? = nil, completion: (() -> Void)? = nil) {
@@ -836,7 +855,13 @@ public class LDClient {
             os_log("%s LDClient.start was called with a timeout greater than %f seconds. We recommend a timeout of less than %f seconds.", log: config.logger, type: .info, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
         }
 
-        start(serviceFactory: nil, config: config, context: context, startWaitSeconds: startWaitSeconds, completion: completion)
+        start(serviceFactory: nil, config: config, context: context, startWaitSeconds: startWaitSeconds) { timedOut in
+            if let completion {
+                DispatchQueue.main.async {
+                    completion(timedOut)
+                }
+            }
+        }
     }
 
     static func start(serviceFactory: ClientServiceCreating?, config: LDConfig, context: LDContext? = nil, startWaitSeconds: TimeInterval, completion: ((_ timedOut: Bool) -> Void)? = nil) {


### PR DESCRIPTION
**Requirements**

Put completions of all public methods into main-thread.
1. Solves inconsistency of completion on unexpected threads. (before some was on main and some not)
2. Solves Obj-C compatibility
3. Solves using library from Swift6 project

**Related issues**

(https://github.com/launchdarkly/ios-client-sdk/issues/419)

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Require customers wrap completions into sendable completions. T



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Main-thread completion dispatch**
> 
> - `setOnline(_:completion:)` now notifies completion on `.main` instead of a global queue
> - All `identify` variants wrap their `completion` callbacks in `DispatchQueue.main.async`
> - Deprecated `identify(context: completion:)` also dispatches completion on `.main`
> - `start(config:context:completion:)` and `start(config:context:startWaitSeconds:completion:)` now invoke provided completions on `.main`
> 
> This standardizes public API completion execution to the main thread across the SDK.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1ffd0bbcdd2fa0262e33206000cabcf9fed5234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->