### PR TITLE
feat: Add support for per-context summary events.

### DIFF
--- a/ContractTests/Source/Controllers/SdkController.swift
+++ b/ContractTests/Source/Controllers/SdkController.swift
@@ -33,7 +33,8 @@ final class SdkController: RouteCollection {
             "event-gzip",
             "optional-event-gzip",
             "client-prereq-events",
-            "polling-gzip"
+            "polling-gzip",
+            "client-per-context-summaries"
         ]
 
         return StatusResponse(

--- a/LaunchDarkly.xcodeproj/project.pbxproj
+++ b/LaunchDarkly.xcodeproj/project.pbxproj
@@ -209,12 +209,11 @@
 		83F0A5641FB5F33800550A95 /* LDConfigSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F0A5631FB5F33800550A95 /* LDConfigSpec.swift */; };
 		83FEF8DD1F266742001CF12C /* FlagSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FEF8DC1F266742001CF12C /* FlagSynchronizer.swift */; };
 		83FEF8DF1F2667E4001CF12C /* EventReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FEF8DE1F2667E4001CF12C /* EventReporter.swift */; };
-		9A18F8382F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
-		9A18F8392F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
-		9A18F83A2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
-		9A18F83B2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
-		9A18F83C2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
-		9A18F83E2F3D463F008F3A61 /* ContextSummarizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F83D2F3D463F008F3A61 /* ContextSummarizerSpec.swift */; };
+		9A47F74A2F3D4CBF0001FD9C /* ContextSummarizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A47F7492F3D4CBF0001FD9C /* ContextSummarizerSpec.swift */; };
+		9A47F74C2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A47F74B2F3D4CCF0001FD9C /* ContextSummarizer.swift */; };
+		9A47F74D2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A47F74B2F3D4CCF0001FD9C /* ContextSummarizer.swift */; };
+		9A47F74E2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A47F74B2F3D4CCF0001FD9C /* ContextSummarizer.swift */; };
+		9A47F74F2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A47F74B2F3D4CCF0001FD9C /* ContextSummarizer.swift */; };
 		A3047D642A606B6000F568E0 /* SDKEnvironmentReporterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3047D5D2A606B6000F568E0 /* SDKEnvironmentReporterSpec.swift */; };
 		A3047D652A606B6000F568E0 /* IOSEnvironmentReporterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3047D5E2A606B6000F568E0 /* IOSEnvironmentReporterSpec.swift */; };
 		A3047D662A606B6000F568E0 /* EnvironmentReporterChainBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3047D5F2A606B6000F568E0 /* EnvironmentReporterChainBaseSpec.swift */; };
@@ -521,8 +520,8 @@
 		83F0A5631FB5F33800550A95 /* LDConfigSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDConfigSpec.swift; sourceTree = "<group>"; };
 		83FEF8DC1F266742001CF12C /* FlagSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlagSynchronizer.swift; sourceTree = "<group>"; };
 		83FEF8DE1F2667E4001CF12C /* EventReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventReporter.swift; sourceTree = "<group>"; };
-		9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextSummarizer.swift; sourceTree = "<group>"; };
-		9A18F83D2F3D463F008F3A61 /* ContextSummarizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextSummarizerSpec.swift; sourceTree = "<group>"; };
+		9A47F7492F3D4CBF0001FD9C /* ContextSummarizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextSummarizerSpec.swift; sourceTree = "<group>"; };
+		9A47F74B2F3D4CCF0001FD9C /* ContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextSummarizer.swift; sourceTree = "<group>"; };
 		A3047D5D2A606B6000F568E0 /* SDKEnvironmentReporterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKEnvironmentReporterSpec.swift; sourceTree = "<group>"; };
 		A3047D5E2A606B6000F568E0 /* IOSEnvironmentReporterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IOSEnvironmentReporterSpec.swift; sourceTree = "<group>"; };
 		A3047D5F2A606B6000F568E0 /* EnvironmentReporterChainBaseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentReporterChainBaseSpec.swift; sourceTree = "<group>"; };
@@ -656,7 +655,7 @@
 		831D8B751F72A48900ED65E8 /* ServiceObjects */ = {
 			isa = PBXGroup;
 			children = (
-				9A18F83D2F3D463F008F3A61 /* ContextSummarizerSpec.swift */,
+				9A47F7492F3D4CBF0001FD9C /* ContextSummarizerSpec.swift */,
 				50EE85C62EA0749C007CC662 /* TimeoutExecutorSpec.swift */,
 				A3047D5B2A606A0000F568E0 /* EnvironmentReporting */,
 				B46F344025E6DB7D0078D45F /* DiagnosticReporterSpec.swift */,
@@ -918,7 +917,7 @@
 		83FEF8D91F2666BF001CF12C /* ServiceObjects */ = {
 			isa = PBXGroup;
 			children = (
-				9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */,
+				9A47F74B2F3D4CCF0001FD9C /* ContextSummarizer.swift */,
 				50EE85C12EA0487F007CC662 /* TimeoutExecutor.swift */,
 				A3A8BCD12B7EAA89009A77E4 /* SheddingQueue.swift */,
 				A358D6CF2A4DD45000270C60 /* EnvironmentReporting */,
@@ -1370,7 +1369,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83906A7B21190B7700D7D3C5 /* DateFormatter.swift in Sources */,
-				9A18F83C2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
+				9A47F74F2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */,
 				831188502113ADEF00D77CB5 /* EnvironmentReporter.swift in Sources */,
 				831188682113AE5600D77CB5 /* ObjcLDClient.swift in Sources */,
 				831188572113AE0B00D77CB5 /* FlagChangeNotifier.swift in Sources */,
@@ -1451,7 +1450,7 @@
 			files = (
 				B468E71224B3C3AC00E0C883 /* ObjcLDEvaluationDetail.swift in Sources */,
 				A36EDFCF2853C50B00D91B05 /* ObjcLDContext.swift in Sources */,
-				9A18F8392F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
+				9A47F74C2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */,
 				831EF34320655E730001C643 /* LDCommon.swift in Sources */,
 				A3C6F7662B84EF0C005B3B61 /* IdentifyTypes.swift in Sources */,
 				831EF34420655E730001C643 /* LDConfig.swift in Sources */,
@@ -1531,7 +1530,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				831D8B6F1F71532300ED65E8 /* HTTPHeaders.swift in Sources */,
-				9A18F83B2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
+				9A47F74D2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */,
 				835E1D3F1F63450A00184DB4 /* ObjcLDClient.swift in Sources */,
 				83EBCBB320DABE1B003A7142 /* FlagRequestTracker.swift in Sources */,
 				837EF3742059C237009D628A /* Log.swift in Sources */,
@@ -1620,7 +1619,6 @@
 				B4F689142497B2FC004D3CE0 /* DiagnosticEventSpec.swift in Sources */,
 				83396BC91F7C3711000E256E /* DarklyServiceSpec.swift in Sources */,
 				3D9A12582A73236800698B8D /* UtilSpec.swift in Sources */,
-				9A18F8382F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
 				83EF67931F9945E800403126 /* EventSpec.swift in Sources */,
 				A3BA7D042BD2BD620000DB28 /* TestContext.swift in Sources */,
 				83B6E3F1222EFA3800FF2A6A /* ThreadSpec.swift in Sources */,
@@ -1651,7 +1649,7 @@
 				830DB3AC22380A3E00D65D25 /* HTTPHeadersSpec.swift in Sources */,
 				831425AF206ABB5300F2EF36 /* EnvironmentReportingMock.swift in Sources */,
 				838AB53F1F72A7D5006F03F5 /* FlagSynchronizerSpec.swift in Sources */,
-				9A18F83E2F3D463F008F3A61 /* ContextSummarizerSpec.swift in Sources */,
+				9A47F74A2F3D4CBF0001FD9C /* ContextSummarizerSpec.swift in Sources */,
 				A3FFE1132B7D4BA2009EF93F /* LDValueDecoderSpec.swift in Sources */,
 				A3570F5A28527B8200CF241A /* LDContextCodableSpec.swift in Sources */,
 				50EE85C72EA0749C007CC662 /* TimeoutExecutorSpec.swift in Sources */,
@@ -1670,7 +1668,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83D9EC752062DEAB004D7FA6 /* LDCommon.swift in Sources */,
-				9A18F83A2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
+				9A47F74E2F3D4CCF0001FD9C /* ContextSummarizer.swift in Sources */,
 				83D9EC762062DEAB004D7FA6 /* LDConfig.swift in Sources */,
 				83EBCBB420DABE1B003A7142 /* FlagRequestTracker.swift in Sources */,
 				83D9EC772062DEAB004D7FA6 /* LDClient.swift in Sources */,

--- a/LaunchDarkly.xcodeproj/project.pbxproj
+++ b/LaunchDarkly.xcodeproj/project.pbxproj
@@ -209,6 +209,12 @@
 		83F0A5641FB5F33800550A95 /* LDConfigSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F0A5631FB5F33800550A95 /* LDConfigSpec.swift */; };
 		83FEF8DD1F266742001CF12C /* FlagSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FEF8DC1F266742001CF12C /* FlagSynchronizer.swift */; };
 		83FEF8DF1F2667E4001CF12C /* EventReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FEF8DE1F2667E4001CF12C /* EventReporter.swift */; };
+		9A18F8382F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
+		9A18F8392F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
+		9A18F83A2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
+		9A18F83B2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
+		9A18F83C2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */; };
+		9A18F83E2F3D463F008F3A61 /* ContextSummarizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A18F83D2F3D463F008F3A61 /* ContextSummarizerSpec.swift */; };
 		A3047D642A606B6000F568E0 /* SDKEnvironmentReporterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3047D5D2A606B6000F568E0 /* SDKEnvironmentReporterSpec.swift */; };
 		A3047D652A606B6000F568E0 /* IOSEnvironmentReporterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3047D5E2A606B6000F568E0 /* IOSEnvironmentReporterSpec.swift */; };
 		A3047D662A606B6000F568E0 /* EnvironmentReporterChainBaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3047D5F2A606B6000F568E0 /* EnvironmentReporterChainBaseSpec.swift */; };
@@ -311,9 +317,9 @@
 		A3BA7CFE2BD05A2A0000DB28 /* LDClientIdentifyHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7CFD2BD05A2A0000DB28 /* LDClientIdentifyHook.swift */; };
 		A3BA7CFF2BD05A2A0000DB28 /* LDClientIdentifyHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7CFD2BD05A2A0000DB28 /* LDClientIdentifyHook.swift */; };
 		A3BA7D002BD05A2A0000DB28 /* LDClientIdentifyHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7CFD2BD05A2A0000DB28 /* LDClientIdentifyHook.swift */; };
+		A3BA7D042BD2BD620000DB28 /* TestContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7D032BD2BD620000DB28 /* TestContext.swift */; };
 		A3BA7D072BD192250000DB28 /* LDClientEvaluationHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7D052BD192250000DB28 /* LDClientEvaluationHookSpec.swift */; };
 		A3BA7D082BD192250000DB28 /* LDClientIdentifyHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7D062BD192250000DB28 /* LDClientIdentifyHookSpec.swift */; };
-		A3BA7D042BD2BD620000DB28 /* TestContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7D032BD2BD620000DB28 /* TestContext.swift */; };
 		A3C6F7622B7FA803005B3B61 /* SheddingQueueSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C6F7612B7FA803005B3B61 /* SheddingQueueSpec.swift */; };
 		A3C6F7642B84EF0C005B3B61 /* IdentifyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C6F7632B84EF0C005B3B61 /* IdentifyTypes.swift */; };
 		A3C6F7652B84EF0C005B3B61 /* IdentifyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C6F7632B84EF0C005B3B61 /* IdentifyTypes.swift */; };
@@ -515,6 +521,8 @@
 		83F0A5631FB5F33800550A95 /* LDConfigSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDConfigSpec.swift; sourceTree = "<group>"; };
 		83FEF8DC1F266742001CF12C /* FlagSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlagSynchronizer.swift; sourceTree = "<group>"; };
 		83FEF8DE1F2667E4001CF12C /* EventReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventReporter.swift; sourceTree = "<group>"; };
+		9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextSummarizer.swift; sourceTree = "<group>"; };
+		9A18F83D2F3D463F008F3A61 /* ContextSummarizerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextSummarizerSpec.swift; sourceTree = "<group>"; };
 		A3047D5D2A606B6000F568E0 /* SDKEnvironmentReporterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKEnvironmentReporterSpec.swift; sourceTree = "<group>"; };
 		A3047D5E2A606B6000F568E0 /* IOSEnvironmentReporterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IOSEnvironmentReporterSpec.swift; sourceTree = "<group>"; };
 		A3047D5F2A606B6000F568E0 /* EnvironmentReporterChainBaseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentReporterChainBaseSpec.swift; sourceTree = "<group>"; };
@@ -548,9 +556,9 @@
 		A3BA7CF22BD05A280000DB28 /* EvaluationSeriesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationSeriesContext.swift; sourceTree = "<group>"; };
 		A3BA7CF82BD05A290000DB28 /* IdentifySeriesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifySeriesContext.swift; sourceTree = "<group>"; };
 		A3BA7CFD2BD05A2A0000DB28 /* LDClientIdentifyHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientIdentifyHook.swift; sourceTree = "<group>"; };
+		A3BA7D032BD2BD620000DB28 /* TestContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestContext.swift; sourceTree = "<group>"; };
 		A3BA7D052BD192250000DB28 /* LDClientEvaluationHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientEvaluationHookSpec.swift; sourceTree = "<group>"; };
 		A3BA7D062BD192250000DB28 /* LDClientIdentifyHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientIdentifyHookSpec.swift; sourceTree = "<group>"; };
-		A3BA7D032BD2BD620000DB28 /* TestContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestContext.swift; sourceTree = "<group>"; };
 		A3C6F7612B7FA803005B3B61 /* SheddingQueueSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheddingQueueSpec.swift; sourceTree = "<group>"; };
 		A3C6F7632B84EF0C005B3B61 /* IdentifyTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyTypes.swift; sourceTree = "<group>"; };
 		A3FFE1122B7D4BA2009EF93F /* LDValueDecoderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDValueDecoderSpec.swift; sourceTree = "<group>"; };
@@ -648,6 +656,7 @@
 		831D8B751F72A48900ED65E8 /* ServiceObjects */ = {
 			isa = PBXGroup;
 			children = (
+				9A18F83D2F3D463F008F3A61 /* ContextSummarizerSpec.swift */,
 				50EE85C62EA0749C007CC662 /* TimeoutExecutorSpec.swift */,
 				A3047D5B2A606A0000F568E0 /* EnvironmentReporting */,
 				B46F344025E6DB7D0078D45F /* DiagnosticReporterSpec.swift */,
@@ -909,6 +918,7 @@
 		83FEF8D91F2666BF001CF12C /* ServiceObjects */ = {
 			isa = PBXGroup;
 			children = (
+				9A18F8372F3D4619008F3A61 /* ContextSummarizer.swift */,
 				50EE85C12EA0487F007CC662 /* TimeoutExecutor.swift */,
 				A3A8BCD12B7EAA89009A77E4 /* SheddingQueue.swift */,
 				A358D6CF2A4DD45000270C60 /* EnvironmentReporting */,
@@ -1360,6 +1370,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83906A7B21190B7700D7D3C5 /* DateFormatter.swift in Sources */,
+				9A18F83C2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
 				831188502113ADEF00D77CB5 /* EnvironmentReporter.swift in Sources */,
 				831188682113AE5600D77CB5 /* ObjcLDClient.swift in Sources */,
 				831188572113AE0B00D77CB5 /* FlagChangeNotifier.swift in Sources */,
@@ -1440,6 +1451,7 @@
 			files = (
 				B468E71224B3C3AC00E0C883 /* ObjcLDEvaluationDetail.swift in Sources */,
 				A36EDFCF2853C50B00D91B05 /* ObjcLDContext.swift in Sources */,
+				9A18F8392F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
 				831EF34320655E730001C643 /* LDCommon.swift in Sources */,
 				A3C6F7662B84EF0C005B3B61 /* IdentifyTypes.swift in Sources */,
 				831EF34420655E730001C643 /* LDConfig.swift in Sources */,
@@ -1519,6 +1531,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				831D8B6F1F71532300ED65E8 /* HTTPHeaders.swift in Sources */,
+				9A18F83B2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
 				835E1D3F1F63450A00184DB4 /* ObjcLDClient.swift in Sources */,
 				83EBCBB320DABE1B003A7142 /* FlagRequestTracker.swift in Sources */,
 				837EF3742059C237009D628A /* Log.swift in Sources */,
@@ -1607,6 +1620,7 @@
 				B4F689142497B2FC004D3CE0 /* DiagnosticEventSpec.swift in Sources */,
 				83396BC91F7C3711000E256E /* DarklyServiceSpec.swift in Sources */,
 				3D9A12582A73236800698B8D /* UtilSpec.swift in Sources */,
+				9A18F8382F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
 				83EF67931F9945E800403126 /* EventSpec.swift in Sources */,
 				A3BA7D042BD2BD620000DB28 /* TestContext.swift in Sources */,
 				83B6E3F1222EFA3800FF2A6A /* ThreadSpec.swift in Sources */,
@@ -1637,6 +1651,7 @@
 				830DB3AC22380A3E00D65D25 /* HTTPHeadersSpec.swift in Sources */,
 				831425AF206ABB5300F2EF36 /* EnvironmentReportingMock.swift in Sources */,
 				838AB53F1F72A7D5006F03F5 /* FlagSynchronizerSpec.swift in Sources */,
+				9A18F83E2F3D463F008F3A61 /* ContextSummarizerSpec.swift in Sources */,
 				A3FFE1132B7D4BA2009EF93F /* LDValueDecoderSpec.swift in Sources */,
 				A3570F5A28527B8200CF241A /* LDContextCodableSpec.swift in Sources */,
 				50EE85C72EA0749C007CC662 /* TimeoutExecutorSpec.swift in Sources */,
@@ -1655,6 +1670,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83D9EC752062DEAB004D7FA6 /* LDCommon.swift in Sources */,
+				9A18F83A2F3D4619008F3A61 /* ContextSummarizer.swift in Sources */,
 				83D9EC762062DEAB004D7FA6 /* LDConfig.swift in Sources */,
 				83EBCBB420DABE1B003A7142 /* FlagRequestTracker.swift in Sources */,
 				83D9EC772062DEAB004D7FA6 /* LDClient.swift in Sources */,
@@ -1839,8 +1855,8 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(PROJECT_DIR)/LaunchDarkly/LaunchDarkly/Support/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 10.1.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 10.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.launchdarkly.Darkly-macOS";
 				PRODUCT_NAME = LaunchDarkly_macOS;
 				SDKROOT = macosx;
@@ -1863,8 +1879,8 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "$(PROJECT_DIR)/LaunchDarkly/LaunchDarkly/Support/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				MARKETING_VERSION = 10.1.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MARKETING_VERSION = 10.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.launchdarkly.Darkly-macOS";
 				PRODUCT_NAME = LaunchDarkly_macOS;
 				SDKROOT = macosx;

--- a/LaunchDarkly/GeneratedCode/mocks.generated.swift
+++ b/LaunchDarkly/GeneratedCode/mocks.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.2.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Foundation

--- a/LaunchDarkly/LaunchDarkly/Models/Event.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Event.swift
@@ -129,9 +129,11 @@ class IdentifyEvent: Event, SubEvent {
 class SummaryEvent: Event, SubEvent {
     let flagRequestTracker: FlagRequestTracker
     let endDate: Date
+    let context: LDContext?
 
-    init(flagRequestTracker: FlagRequestTracker, endDate: Date = Date()) {
+    init(flagRequestTracker: FlagRequestTracker, context: LDContext? = nil, endDate: Date = Date()) {
         self.flagRequestTracker = flagRequestTracker
+        self.context = context
         self.endDate = endDate
         super.init(kind: .summary)
     }
@@ -141,5 +143,8 @@ class SummaryEvent: Event, SubEvent {
         try container.encode(flagRequestTracker.startDate, forKey: .startDate)
         try container.encode(endDate, forKey: .endDate)
         try container.encode(flagRequestTracker.flagCounters, forKey: .features)
+        if let context = context {
+            try container.encode(context, forKey: .context)
+        }
     }
 }

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/ContextSummarizer.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/ContextSummarizer.swift
@@ -20,17 +20,7 @@ class ContextSummarizer {
     /// Creates a new tracker for the context if one doesn't exist, or reuses the existing one.
     func trackRequest(flagKey: LDFlagKey, reportedValue: LDValue, featureFlag: FeatureFlag?, defaultValue: LDValue, context: LDContext) {
         let contextHashKey = context.contextHash()
-
-        if trackers[contextHashKey] == nil {
-            // Create filtered context for privacy
-            var filteredContext = LDContext(copyFrom: context)
-            filteredContext.redactAnonymousAttributes = true
-
-            trackers[contextHashKey] = TrackerWithContext(
-                tracker: FlagRequestTracker(logger: logger),
-                context: filteredContext
-            )
-        }
+        ensureTrackerExists(for: context, hashKey: contextHashKey)
 
         trackers[contextHashKey]?.tracker.trackRequest(
             flagKey: flagKey,
@@ -38,6 +28,20 @@ class ContextSummarizer {
             featureFlag: featureFlag,
             defaultValue: defaultValue,
             context: context
+        )
+    }
+
+    /// Ensures a tracker exists for the context hash, creating one if needed.
+    private func ensureTrackerExists(for context: LDContext, hashKey: String) {
+        guard trackers[hashKey] == nil else { return }
+
+        // Create filtered context for privacy
+        var filteredContext = LDContext(copyFrom: context)
+        filteredContext.redactAnonymousAttributes = true
+
+        trackers[hashKey] = TrackerWithContext(
+            tracker: FlagRequestTracker(logger: logger),
+            context: filteredContext
         )
     }
 

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/ContextSummarizer.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/ContextSummarizer.swift
@@ -1,0 +1,58 @@
+import Foundation
+import OSLog
+
+/// Manages per-context summary events by tracking separate FlagRequestTracker instances for each unique context.
+/// Each context is identified by its hash, and summaries are generated separately for each context during flush.
+class ContextSummarizer {
+    private var trackers: [String: TrackerWithContext] = [:]
+    private let logger: OSLog
+
+    struct TrackerWithContext {
+        var tracker: FlagRequestTracker
+        let context: LDContext
+    }
+
+    init(logger: OSLog) {
+        self.logger = logger
+    }
+
+    /// Tracks a flag evaluation request for a specific context.
+    /// Creates a new tracker for the context if one doesn't exist, or reuses the existing one.
+    func trackRequest(flagKey: LDFlagKey, reportedValue: LDValue, featureFlag: FeatureFlag?, defaultValue: LDValue, context: LDContext) {
+        let contextHashKey = context.contextHash()
+
+        if trackers[contextHashKey] == nil {
+            // Create filtered context for privacy
+            var filteredContext = LDContext(copyFrom: context)
+            filteredContext.redactAnonymousAttributes = true
+
+            trackers[contextHashKey] = TrackerWithContext(
+                tracker: FlagRequestTracker(logger: logger),
+                context: filteredContext
+            )
+        }
+
+        trackers[contextHashKey]?.tracker.trackRequest(
+            flagKey: flagKey,
+            reportedValue: reportedValue,
+            featureFlag: featureFlag,
+            defaultValue: defaultValue,
+            context: context
+        )
+    }
+
+    /// Returns all tracker-context pairs for summary event generation.
+    func getSummaries() -> [(tracker: FlagRequestTracker, context: LDContext)] {
+        return trackers.values.map { ($0.tracker, $0.context) }
+    }
+
+    /// Returns true if any tracker has logged requests.
+    var hasLoggedRequests: Bool {
+        return trackers.values.contains { $0.tracker.hasLoggedRequests }
+    }
+
+    /// Clears all trackers.
+    func clear() {
+        trackers.removeAll()
+    }
+}

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/EventReporter.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/EventReporter.swift
@@ -43,7 +43,7 @@ class EventReporter: EventReporting {
     private let eventQueue = DispatchQueue(label: "com.launchdarkly.eventSyncQueue", qos: .userInitiated)
     // These fields should only be used synchronized on the eventQueue
     private(set) var eventStore: [Event] = []
-    private(set) var flagRequestTracker: FlagRequestTracker
+    private(set) var contextSummarizer: ContextSummarizer
 
     private var timerQueue = DispatchQueue(label: "com.launchdarkly.EventReporter.timerQueue")
     private var eventReportTimer: TimeResponding?
@@ -55,7 +55,7 @@ class EventReporter: EventReporting {
         self.service = service
         self.onSyncComplete = onSyncComplete
         self.lastEventResponseDate = Date()
-        self.flagRequestTracker = FlagRequestTracker(logger: service.config.logger)
+        self.contextSummarizer = ContextSummarizer(logger: service.config.logger)
     }
 
     func record(_ event: Event) {
@@ -78,7 +78,7 @@ class EventReporter: EventReporting {
         let recordingDebugEvent = featureFlag?.shouldCreateDebugEvents(lastEventReportResponseTime: lastEventResponseDate) ?? false
 
         eventQueue.sync {
-            flagRequestTracker.trackRequest(flagKey: flagKey, reportedValue: value, featureFlag: featureFlag, defaultValue: defaultValue, context: context)
+            contextSummarizer.trackRequest(flagKey: flagKey, reportedValue: value, featureFlag: featureFlag, defaultValue: defaultValue, context: context)
             if recordingFeatureEvent {
                 let featureEvent = FeatureEvent(key: flagKey, context: context, value: value, defaultValue: defaultValue, featureFlag: featureFlag, includeReason: includeReason, isDebug: false)
                 recordNoSync(featureEvent)
@@ -120,10 +120,13 @@ class EventReporter: EventReporting {
             return
         }
 
-        if flagRequestTracker.hasLoggedRequests {
-            let summaryEvent = SummaryEvent(flagRequestTracker: flagRequestTracker)
-            self.eventStore.append(summaryEvent)
-            flagRequestTracker = FlagRequestTracker(logger: service.config.logger)
+        if contextSummarizer.hasLoggedRequests {
+            let summaries = contextSummarizer.getSummaries()
+            for summary in summaries {
+                let summaryEvent = SummaryEvent(flagRequestTracker: summary.tracker, context: summary.context)
+                self.eventStore.append(summaryEvent)
+            }
+            contextSummarizer.clear()
         }
 
         guard !eventStore.isEmpty
@@ -231,8 +234,8 @@ extension EventReporter: TypeIdentifying { }
             lastEventResponseDate = date
         }
 
-        func setFlagRequestTracker(_ tracker: FlagRequestTracker) {
-            flagRequestTracker = tracker
+        func setContextSummarizer(_ summarizer: ContextSummarizer) {
+            contextSummarizer = summarizer
         }
     }
 #endif

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/EventReporter.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/EventReporter.swift
@@ -233,9 +233,5 @@ extension EventReporter: TypeIdentifying { }
         func setLastEventResponseDate(_ date: Date) {
             lastEventResponseDate = date
         }
-
-        func setContextSummarizer(_ summarizer: ContextSummarizer) {
-            contextSummarizer = summarizer
-        }
     }
 #endif

--- a/LaunchDarkly/LaunchDarklyTests/Mocks/DarklyServiceMock.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Mocks/DarklyServiceMock.swift
@@ -233,7 +233,7 @@ extension DarklyServiceMock {
         let stubResponse: HTTPStubsResponseBlock = success ? { _ in
             HTTPStubsResponse(data: Data(), statusCode: Int32(HTTPURLResponse.StatusCodes.accepted), headers: nil)
         } : { _ in
-            HTTPStubsResponse(error: Constants.error)
+            HTTPStubsResponse(error: Constants.error).responseTime(0)
         }
         stubRequest(passingTest: eventRequestStubTest, stub: stubResponse, name: "Event report stub") { request, _, _ in
             activate?(request)

--- a/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
@@ -610,15 +610,13 @@ final class DarklyServiceSpec: QuickSpec {
                 beforeEach {
                     // Set up stub before waitUntil to ensure it's registered before the request is made.
                     // On macOS 15/Xcode 16, OHHTTPStubs error responses may not immediately trigger
-                    // the completion handler, so we ensure the stub is ready first.
+                    // the completion handler, so we ensure the stub is ready first and use responseTime(0).
                     testContext.serviceMock.stubEventRequest(success: false) { eventRequest = $0 }
                     waitUntil { done in
                         testContext.service.publishEventData(testData, UUID().uuidString) { response in
                             responses = (response.data, response.urlResponse, response.error)
-                            // Ensure done() is called on the main queue, as waitUntil may require it
-                            DispatchQueue.main.async {
-                                done()
-                            }
+                            // Call done() directly - it's thread-safe and waitUntil already manages the main runloop
+                            done()
                         }
                     }
                 }
@@ -734,10 +732,8 @@ final class DarklyServiceSpec: QuickSpec {
                     waitUntil { done in
                         testContext.service.publishDiagnostic(diagnosticEvent: self.stubDiagnostic()) { response in
                             responses = (response.data, response.urlResponse, response.error)
-                            // Ensure done() is called on the main queue, as waitUntil may require it
-                            DispatchQueue.main.async {
-                                done()
-                            }
+                            // Call done() directly - it's thread-safe and waitUntil already manages the main runloop
+                            done()
                         }
                     }
                 }

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ContextSummarizerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ContextSummarizerSpec.swift
@@ -1,0 +1,303 @@
+import Foundation
+import Quick
+import Nimble
+@testable import LaunchDarkly
+
+final class ContextSummarizerSpec: QuickSpec {
+    override func spec() {
+        describe("ContextSummarizer") {
+            var summarizer: ContextSummarizer!
+            var logger: OSLog!
+            var context1: LDContext!
+            var context2: LDContext!
+            var featureFlag: FeatureFlag!
+
+            beforeEach {
+                logger = OSLog(subsystem: "com.launchdarkly.test", category: "test")
+                summarizer = ContextSummarizer(logger: logger)
+                context1 = LDContext.stub()
+                context2 = LDContext(key: "user-key-2", kind: "user", name: "Test User 2")
+                featureFlag = FeatureFlag.stub()
+            }
+
+            describe("trackRequest") {
+                context("single context") {
+                    it("creates a tracker for the context") {
+                        summarizer.trackRequest(
+                            flagKey: "flag1",
+                            reportedValue: .bool(true),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: context1
+                        )
+
+                        let summaries = summarizer.getSummaries()
+                        expect(summaries.count) == 1
+                        expect(summaries[0].tracker.hasLoggedRequests) == true
+                    }
+
+                    it("tracks multiple flag evaluations for same context") {
+                        summarizer.trackRequest(
+                            flagKey: "flag1",
+                            reportedValue: .bool(true),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: context1
+                        )
+                        summarizer.trackRequest(
+                            flagKey: "flag2",
+                            reportedValue: .string("value"),
+                            featureFlag: featureFlag,
+                            defaultValue: .string("default"),
+                            context: context1
+                        )
+
+                        let summaries = summarizer.getSummaries()
+                        expect(summaries.count) == 1
+                        expect(summaries[0].tracker.flagCounters.count) == 2
+                    }
+                }
+
+                context("multiple contexts") {
+                    it("creates separate trackers for different contexts") {
+                        summarizer.trackRequest(
+                            flagKey: "flag1",
+                            reportedValue: .bool(true),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: context1
+                        )
+                        summarizer.trackRequest(
+                            flagKey: "flag1",
+                            reportedValue: .bool(false),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: context2
+                        )
+
+                        let summaries = summarizer.getSummaries()
+                        expect(summaries.count) == 2
+                    }
+
+                    it("reuses tracker when same context is used again") {
+                        summarizer.trackRequest(
+                            flagKey: "flag1",
+                            reportedValue: .bool(true),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: context1
+                        )
+                        summarizer.trackRequest(
+                            flagKey: "flag2",
+                            reportedValue: .bool(true),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: context2
+                        )
+                        summarizer.trackRequest(
+                            flagKey: "flag3",
+                            reportedValue: .bool(true),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: context1
+                        )
+
+                        let summaries = summarizer.getSummaries()
+                        expect(summaries.count) == 2
+
+                        let context1Summaries = summaries.filter { $0.context.contextHash() == context1.contextHash() }
+                        expect(context1Summaries.count) == 1
+                        expect(context1Summaries[0].tracker.flagCounters.count) == 2
+                    }
+                }
+
+                context("context privacy") {
+                    it("stores filtered context with redactAnonymousAttributes flag") {
+                        var anonymousContext = LDContext(key: "anon-key", kind: "user")
+                        anonymousContext.anonymous = true
+
+                        summarizer.trackRequest(
+                            flagKey: "flag1",
+                            reportedValue: .bool(true),
+                            featureFlag: featureFlag,
+                            defaultValue: .bool(false),
+                            context: anonymousContext
+                        )
+
+                        let summaries = summarizer.getSummaries()
+                        expect(summaries.count) == 1
+                        expect(summaries[0].context.redactAnonymousAttributes) == true
+                    }
+                }
+            }
+
+            describe("getSummaries") {
+                it("returns empty array when no requests tracked") {
+                    let summaries = summarizer.getSummaries()
+                    expect(summaries.count) == 0
+                }
+
+                it("returns correct tracker-context pairs") {
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(true),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context1
+                    )
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(false),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context2
+                    )
+
+                    let summaries = summarizer.getSummaries()
+                    expect(summaries.count) == 2
+
+                    let contextHashes = summaries.map { $0.context.contextHash() }
+                    expect(contextHashes).to(contain(context1.contextHash()))
+                    expect(contextHashes).to(contain(context2.contextHash()))
+                }
+            }
+
+            describe("hasLoggedRequests") {
+                it("returns false when no requests tracked") {
+                    expect(summarizer.hasLoggedRequests) == false
+                }
+
+                it("returns true when requests have been tracked") {
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(true),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context1
+                    )
+
+                    expect(summarizer.hasLoggedRequests) == true
+                }
+
+                it("returns true when any tracker has logged requests") {
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(true),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context1
+                    )
+                    summarizer.trackRequest(
+                        flagKey: "flag2",
+                        reportedValue: .bool(false),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context2
+                    )
+
+                    expect(summarizer.hasLoggedRequests) == true
+                }
+            }
+
+            describe("clear") {
+                it("removes all trackers") {
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(true),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context1
+                    )
+                    summarizer.trackRequest(
+                        flagKey: "flag2",
+                        reportedValue: .bool(false),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context2
+                    )
+
+                    expect(summarizer.hasLoggedRequests) == true
+                    expect(summarizer.getSummaries().count) == 2
+
+                    summarizer.clear()
+
+                    expect(summarizer.hasLoggedRequests) == false
+                    expect(summarizer.getSummaries().count) == 0
+                }
+
+                it("allows tracking new requests after clear") {
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(true),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context1
+                    )
+                    summarizer.clear()
+
+                    summarizer.trackRequest(
+                        flagKey: "flag2",
+                        reportedValue: .bool(false),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: context2
+                    )
+
+                    expect(summarizer.hasLoggedRequests) == true
+                    expect(summarizer.getSummaries().count) == 1
+                    expect(summarizer.getSummaries()[0].context.contextHash()) == context2.contextHash()
+                }
+            }
+
+            describe("multi-context support") {
+                it("handles multi-kind contexts correctly") {
+                    let multiContext = try! LDContext.createMulti(contexts: [
+                        LDContext(key: "user-1", kind: "user"),
+                        LDContext(key: "org-1", kind: "org")
+                    ])
+
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(true),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: multiContext
+                    )
+
+                    let summaries = summarizer.getSummaries()
+                    expect(summaries.count) == 1
+                    expect(summaries[0].context.contextHash()) == multiContext.contextHash()
+                }
+
+                it("treats different multi-contexts as separate") {
+                    let multiContext1 = try! LDContext.createMulti(contexts: [
+                        LDContext(key: "user-1", kind: "user"),
+                        LDContext(key: "org-1", kind: "org")
+                    ])
+                    let multiContext2 = try! LDContext.createMulti(contexts: [
+                        LDContext(key: "user-2", kind: "user"),
+                        LDContext(key: "org-2", kind: "org")
+                    ])
+
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(true),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: multiContext1
+                    )
+                    summarizer.trackRequest(
+                        flagKey: "flag1",
+                        reportedValue: .bool(false),
+                        featureFlag: featureFlag,
+                        defaultValue: .bool(false),
+                        context: multiContext2
+                    )
+
+                    let summaries = summarizer.getSummaries()
+                    expect(summaries.count) == 2
+                }
+            }
+        }
+    }
+}

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ContextSummarizerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/ContextSummarizerSpec.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Quick
 import Nimble
+import OSLog
 @testable import LaunchDarkly
 
 final class ContextSummarizerSpec: QuickSpec {
@@ -10,14 +11,17 @@ final class ContextSummarizerSpec: QuickSpec {
             var logger: OSLog!
             var context1: LDContext!
             var context2: LDContext!
-            var featureFlag: FeatureFlag!
+            var featureFlag: FeatureFlag?
 
             beforeEach {
                 logger = OSLog(subsystem: "com.launchdarkly.test", category: "test")
                 summarizer = ContextSummarizer(logger: logger)
+                // Create two different contexts for testing
                 context1 = LDContext.stub()
-                context2 = LDContext(key: "user-key-2", kind: "user", name: "Test User 2")
-                featureFlag = FeatureFlag.stub()
+                var builder2 = LDContextBuilder(key: "user-key-2")
+                builder2.name("Test User 2")
+                context2 = try! builder2.build().get()
+                featureFlag = FeatureFlag(flagKey: "test-flag", value: .bool(true), variation: 1, flagVersion: 1, trackEvents: false)
             }
 
             describe("trackRequest") {
@@ -113,8 +117,9 @@ final class ContextSummarizerSpec: QuickSpec {
 
                 context("context privacy") {
                     it("stores filtered context with redactAnonymousAttributes flag") {
-                        var anonymousContext = LDContext(key: "anon-key", kind: "user")
-                        anonymousContext.anonymous = true
+                        var builder = LDContextBuilder(key: "anon-key")
+                        builder.anonymous(true)
+                        let anonymousContext = try! builder.build().get()
 
                         summarizer.trackRequest(
                             flagKey: "flag1",
@@ -251,10 +256,18 @@ final class ContextSummarizerSpec: QuickSpec {
 
             describe("multi-context support") {
                 it("handles multi-kind contexts correctly") {
-                    let multiContext = try! LDContext.createMulti(contexts: [
-                        LDContext(key: "user-1", kind: "user"),
-                        LDContext(key: "org-1", kind: "org")
-                    ])
+                    var userBuilder = LDContextBuilder(key: "user-1")
+                    userBuilder.kind("user")
+                    let userContext = try! userBuilder.build().get()
+
+                    var orgBuilder = LDContextBuilder(key: "org-1")
+                    orgBuilder.kind("org")
+                    let orgContext = try! orgBuilder.build().get()
+
+                    var multiBuilder = LDMultiContextBuilder()
+                    multiBuilder.addContext(userContext)
+                    multiBuilder.addContext(orgContext)
+                    let multiContext = try! multiBuilder.build().get()
 
                     summarizer.trackRequest(
                         flagKey: "flag1",
@@ -270,14 +283,31 @@ final class ContextSummarizerSpec: QuickSpec {
                 }
 
                 it("treats different multi-contexts as separate") {
-                    let multiContext1 = try! LDContext.createMulti(contexts: [
-                        LDContext(key: "user-1", kind: "user"),
-                        LDContext(key: "org-1", kind: "org")
-                    ])
-                    let multiContext2 = try! LDContext.createMulti(contexts: [
-                        LDContext(key: "user-2", kind: "user"),
-                        LDContext(key: "org-2", kind: "org")
-                    ])
+                    var user1Builder = LDContextBuilder(key: "user-1")
+                    user1Builder.kind("user")
+                    let user1Context = try! user1Builder.build().get()
+
+                    var org1Builder = LDContextBuilder(key: "org-1")
+                    org1Builder.kind("org")
+                    let org1Context = try! org1Builder.build().get()
+
+                    var multi1Builder = LDMultiContextBuilder()
+                    multi1Builder.addContext(user1Context)
+                    multi1Builder.addContext(org1Context)
+                    let multiContext1 = try! multi1Builder.build().get()
+
+                    var user2Builder = LDContextBuilder(key: "user-2")
+                    user2Builder.kind("user")
+                    let user2Context = try! user2Builder.build().get()
+
+                    var org2Builder = LDContextBuilder(key: "org-2")
+                    org2Builder.kind("org")
+                    let org2Context = try! org2Builder.build().get()
+
+                    var multi2Builder = LDMultiContextBuilder()
+                    multi2Builder.addContext(user2Context)
+                    multi2Builder.addContext(org2Context)
+                    let multiContext2 = try! multi2Builder.build().get()
 
                     summarizer.trackRequest(
                         flagKey: "flag1",

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/EventReporterSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/EventReporterSpec.swift
@@ -227,7 +227,15 @@ final class EventReporterSpec: QuickSpec {
                                 })
                                 testContext.eventReporter.isOnline = true
                                 testContext.recordEvents(Event.Kind.nonSummaryKinds.count)
-                                testContext.eventReporter.setFlagRequestTracker(FlagRequestTracker.stub())
+                                // Track some flag evaluations to populate the contextSummarizer
+                                testContext.eventReporter.recordFlagEvaluationEvents(
+                                    flagKey: "test-flag",
+                                    value: .bool(true),
+                                    defaultValue: .bool(false),
+                                    featureFlag: nil,
+                                    context: testContext.context,
+                                    includeReason: false
+                                )
                                 testContext.eventReporter.flush(completion: nil)
                             }
                         }
@@ -246,7 +254,7 @@ final class EventReporterSpec: QuickSpec {
                             expect(testContext.diagnosticCache.recordEventsInLastBatchReceivedEventsInLastBatch) == Event.Kind.nonSummaryKinds.count + 1
                             expect(testContext.eventReporter.eventStore.isEmpty) == true
                             expect(testContext.eventReporter.lastEventResponseDate) == testContext.eventStubResponseDate
-                            expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == false
+                            expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == false
                             expect(testContext.syncResult).to(beNil())
                         }
                     }
@@ -271,7 +279,7 @@ final class EventReporterSpec: QuickSpec {
                             expect(testContext.diagnosticCache.recordEventsInLastBatchReceivedEventsInLastBatch) == testContext.events.count
                             expect(testContext.eventReporter.eventStore.isEmpty) == true
                             expect(testContext.eventReporter.lastEventResponseDate) == testContext.eventStubResponseDate
-                            expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == false
+                            expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == false
                             expect(testContext.syncResult).to(beNil())
                         }
                     }
@@ -283,7 +291,15 @@ final class EventReporterSpec: QuickSpec {
                                     syncComplete()
                                 })
                                 testContext.eventReporter.isOnline = true
-                                testContext.eventReporter.setFlagRequestTracker(FlagRequestTracker.stub())
+                                // Track some flag evaluations to populate the contextSummarizer
+                                testContext.eventReporter.recordFlagEvaluationEvents(
+                                    flagKey: "test-flag",
+                                    value: .bool(true),
+                                    defaultValue: .bool(false),
+                                    featureFlag: nil,
+                                    context: testContext.context,
+                                    includeReason: false
+                                )
                                 testContext.eventReporter.flush(completion: nil)
                             }
                         }
@@ -301,7 +317,7 @@ final class EventReporterSpec: QuickSpec {
                             expect(testContext.diagnosticCache.recordEventsInLastBatchReceivedEventsInLastBatch) == 1
                             expect(testContext.eventReporter.eventStore.isEmpty) == true
                             expect(testContext.eventReporter.lastEventResponseDate) == testContext.eventStubResponseDate
-                            expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == false
+                            expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == false
                             expect(testContext.syncResult).to(beNil())
                         }
                     }
@@ -322,7 +338,7 @@ final class EventReporterSpec: QuickSpec {
                             expect(testContext.diagnosticCache.recordEventsInLastBatchCallCount) == 0
                             expect(testContext.eventReporter.eventStore.isEmpty) == true
                             expect(testContext.eventReporter.lastEventResponseDate) == Date.distantPast
-                            expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == false
+                            expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == false
                             expect(testContext.syncResult).to(beNil())
                         }
                     }
@@ -337,7 +353,15 @@ final class EventReporterSpec: QuickSpec {
                                 })
                                 testContext.eventReporter.isOnline = true
                                 testContext.recordEvents(Event.Kind.nonSummaryKinds.count)
-                                testContext.eventReporter.setFlagRequestTracker(FlagRequestTracker.stub())
+                                // Track some flag evaluations to populate the contextSummarizer
+                                testContext.eventReporter.recordFlagEvaluationEvents(
+                                    flagKey: "test-flag",
+                                    value: .bool(true),
+                                    defaultValue: .bool(false),
+                                    featureFlag: nil,
+                                    context: testContext.context,
+                                    includeReason: false
+                                )
                                 testContext.eventReporter.flush(completion: nil)
                             }
                         }
@@ -356,7 +380,7 @@ final class EventReporterSpec: QuickSpec {
                             expect(testContext.diagnosticCache.recordEventsInLastBatchCallCount) == 1
                             expect(testContext.diagnosticCache.recordEventsInLastBatchReceivedEventsInLastBatch) == Event.Kind.nonSummaryKinds.count + 1
                             expect(testContext.eventReporter.lastEventResponseDate) == Date.distantPast
-                            expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == false
+                            expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == false
                             guard case let .request(error) = testContext.syncResult
                             else {
                                 fail("Expected error result for event send")
@@ -374,7 +398,15 @@ final class EventReporterSpec: QuickSpec {
                                 })
                                 testContext.eventReporter.isOnline = true
                                 testContext.recordEvents(Event.Kind.nonSummaryKinds.count)
-                                testContext.eventReporter.setFlagRequestTracker(FlagRequestTracker.stub())
+                                // Track some flag evaluations to populate the contextSummarizer
+                                testContext.eventReporter.recordFlagEvaluationEvents(
+                                    flagKey: "test-flag",
+                                    value: .bool(true),
+                                    defaultValue: .bool(false),
+                                    featureFlag: nil,
+                                    context: testContext.context,
+                                    includeReason: false
+                                )
                                 testContext.eventReporter.flush(completion: nil)
                             }
                         }
@@ -393,7 +425,7 @@ final class EventReporterSpec: QuickSpec {
                             expect(testContext.diagnosticCache.recordEventsInLastBatchCallCount) == 1
                             expect(testContext.diagnosticCache.recordEventsInLastBatchReceivedEventsInLastBatch) == Event.Kind.nonSummaryKinds.count + 1
                             expect(testContext.eventReporter.lastEventResponseDate) == Date.distantPast
-                            expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == false
+                            expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == false
                             let expectedError = testContext.serviceMock.errorEventHTTPURLResponse
                             guard case let .response(error) = testContext.syncResult
                             else {
@@ -414,7 +446,15 @@ final class EventReporterSpec: QuickSpec {
                                 })
                                 testContext.eventReporter.isOnline = true
                                 testContext.recordEvents(Event.Kind.nonSummaryKinds.count)
-                                testContext.eventReporter.setFlagRequestTracker(FlagRequestTracker.stub())
+                                // Track some flag evaluations to populate the contextSummarizer
+                                testContext.eventReporter.recordFlagEvaluationEvents(
+                                    flagKey: "test-flag",
+                                    value: .bool(true),
+                                    defaultValue: .bool(false),
+                                    featureFlag: nil,
+                                    context: testContext.context,
+                                    includeReason: false
+                                )
                                 testContext.eventReporter.flush(completion: nil)
                             }
                         }
@@ -433,7 +473,7 @@ final class EventReporterSpec: QuickSpec {
                             expect(testContext.diagnosticCache.recordEventsInLastBatchCallCount) == 1
                             expect(testContext.diagnosticCache.recordEventsInLastBatchReceivedEventsInLastBatch) == Event.Kind.nonSummaryKinds.count + 1
                             expect(testContext.eventReporter.lastEventResponseDate) == Date.distantPast
-                            expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == false
+                            expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == false
                             guard case let .request(error) = testContext.syncResult
                             else {
                                 fail("Expected error result for event send")
@@ -452,7 +492,15 @@ final class EventReporterSpec: QuickSpec {
                             syncComplete()
                         })
                         testContext.recordEvents(Event.Kind.nonSummaryKinds.count)
-                        testContext.eventReporter.setFlagRequestTracker(FlagRequestTracker.stub())
+                        // Track some flag evaluations to populate the contextSummarizer
+                        testContext.eventReporter.recordFlagEvaluationEvents(
+                            flagKey: "test-flag",
+                            value: .bool(true),
+                            defaultValue: .bool(false),
+                            featureFlag: nil,
+                            context: testContext.context,
+                            includeReason: false
+                        )
                         testContext.eventReporter.flush(completion: nil)
                     }
                 }
@@ -463,7 +511,7 @@ final class EventReporterSpec: QuickSpec {
                     expect(testContext.diagnosticCache.recordEventsInLastBatchCallCount) == 0
                     expect(testContext.eventReporter.eventStore) == testContext.events
                     expect(testContext.eventReporter.lastEventResponseDate) == Date.distantPast
-                    expect(testContext.eventReporter.flagRequestTracker.hasLoggedRequests) == true
+                    expect(testContext.eventReporter.contextSummarizer.hasLoggedRequests) == true
                     guard case .isOffline = testContext.syncResult
                     else {
                         fail("Expected error .isOffline result for event send")
@@ -482,22 +530,28 @@ final class EventReporterSpec: QuickSpec {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
                 reporter.recordFlagEvaluationEvents(flagKey: "flag-key", value: "a", defaultValue: "b", featureFlag: nil, context: context, includeReason: true)
                 expect(reporter.eventStore.count) == 0
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.value) == "a"
             }
             it("untracked flag") {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
                 let flag = FeatureFlag(flagKey: "unused", value: nil, variation: 1, flagVersion: 2, trackEvents: false)
                 reporter.recordFlagEvaluationEvents(flagKey: "flag-key", value: "a", defaultValue: "b", featureFlag: flag, context: context, includeReason: true)
                 expect(reporter.eventStore.count) == 0
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
             }
             it("tracked flag") {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
@@ -511,22 +565,28 @@ final class EventReporterSpec: QuickSpec {
                 expect((reporter.eventStore[0] as? FeatureEvent)?.defaultValue) == "b"
                 expect((reporter.eventStore[0] as? FeatureEvent)?.featureFlag) == flag
                 expect((reporter.eventStore[0] as? FeatureEvent)?.includeReason) == true
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
             }
             it("debug until past date") {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
                 let flag = FeatureFlag(flagKey: "unused", value: nil, variation: 1, flagVersion: 2, trackEvents: false, debugEventsUntilDate: Date().addingTimeInterval(-1.0))
                 reporter.recordFlagEvaluationEvents(flagKey: "flag-key", value: "a", defaultValue: "b", featureFlag: flag, context: context, includeReason: true)
                 expect(reporter.eventStore.count) == 0
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
             }
             it("debug until future date") {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
@@ -540,11 +600,14 @@ final class EventReporterSpec: QuickSpec {
                 expect((reporter.eventStore[0] as? FeatureEvent)?.defaultValue) == "b"
                 expect((reporter.eventStore[0] as? FeatureEvent)?.featureFlag) == flag
                 expect((reporter.eventStore[0] as? FeatureEvent)?.includeReason) == false
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
             }
             it("debug until future date earlier than service date") {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
@@ -552,11 +615,14 @@ final class EventReporterSpec: QuickSpec {
                 let flag = FeatureFlag(flagKey: "unused", value: nil, variation: 1, flagVersion: 2, trackEvents: false, debugEventsUntilDate: Date().addingTimeInterval(3.0))
                 reporter.recordFlagEvaluationEvents(flagKey: "flag-key", value: "a", defaultValue: "b", featureFlag: flag, context: context, includeReason: true)
                 expect(reporter.eventStore.count) == 0
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
             }
             it("tracked flag and debug date in future") {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
@@ -580,11 +646,14 @@ final class EventReporterSpec: QuickSpec {
                 expect(debugEvent?.defaultValue) == "b"
                 expect(debugEvent?.featureFlag) == flag
                 expect(debugEvent?.includeReason) == false
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: 1, version: 2)]?.value) == "a"
             }
             it("records events concurrently") {
                 let reporter = EventReporter(service: serviceMock, onSyncComplete: nil)
@@ -601,11 +670,14 @@ final class EventReporterSpec: QuickSpec {
                 expect(reporter.eventStore.count) == 20
                 expect(reporter.eventStore.filter { $0.kind == .feature }.count) == 10
                 expect(reporter.eventStore.filter { $0.kind == .debug }.count) == 10
-                expect(reporter.flagRequestTracker.hasLoggedRequests) == true
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.defaultValue) == "b"
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.count) == 10
-                expect(reporter.flagRequestTracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.value) == "a"
+                expect(reporter.contextSummarizer.hasLoggedRequests) == true
+                let summaries = reporter.contextSummarizer.getSummaries()
+                expect(summaries.count) == 1
+                let tracker = summaries[0].tracker
+                expect(tracker.flagCounters["flag-key"]?.defaultValue) == "b"
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters.count) == 1
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.count) == 10
+                expect(tracker.flagCounters["flag-key"]?.flagValueCounters[CounterKey(variation: nil, version: nil)]?.value) == "a"
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes event summarization and payload shape by emitting multiple summary events (and sometimes including `context`), which could affect analytics volume and server compatibility; coverage is improved via new focused tests.
> 
> **Overview**
> **Per-context summary events:** Replaces the single `FlagRequestTracker` in `EventReporter` with a new `ContextSummarizer` that maintains one tracker per `LDContext` (keyed by `contextHash()`), emitting *multiple* `SummaryEvent`s during flush—each optionally including a redacted context payload.
> 
> Adds `ContextSummarizer` plus comprehensive unit tests, updates `SummaryEvent` encoding to support an optional `context`, and updates contract-test SDK capabilities to include `client-per-context-summaries`. Also adjusts OHHTTPStubs failure behavior (`responseTime(0)`) and simplifies `waitUntil` completion handling to reduce test flakiness, and refreshes Sourcery-generated mocks header / Xcode project file references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 609ea13a64f4cbef7bf10981ef9b5ee3a97dde17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->