### PR TITLE
ci: upping iPhone emulator version used with xcode 16

### DIFF
--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/ci
         with:
           xcode-version: 16.4.0
-          ios-sim: 'platform=iOS Simulator,name=iPhone 15'
+          ios-sim: 'platform=iOS Simulator,name=iPhone 16'
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: ./.github/actions/ci
         with:
           xcode-version: 16.4.0
-          ios-sim: 'platform=iOS Simulator,name=iPhone 15'
+          ios-sim: 'platform=iOS Simulator,name=iPhone 16'
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           xcode-version: 16.4.0
-          ios-sim: 'platform=iOS Simulator,name=iPhone 15'
+          ios-sim: 'platform=iOS Simulator,name=iPhone 16'
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that just switches the simulator device target; risk is limited to potential CI instability if the iPhone 16 simulator image isn’t available on runners.
> 
> **Overview**
> Updates the GitHub Actions `manual-publish-docs`, `manual-publish`, and `release-please` workflows to run the shared `./.github/actions/ci` step against the `iPhone 16` simulator (was `iPhone 15`) while keeping `xcode-version: 16.4.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 114607baf479204fd9dadadb3811acfa7d407f9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->