### PR TITLE
chore: Fix incorrect branch references

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -26,8 +26,11 @@ runs:
 
     - name: Install mint
       shell: bash
-      run: |
-        brew install mint
+      run: brew install mint
+
+    - name: Bootstrap mint packages
+      shell: bash
+      run: mint bootstrap
 
     - name: Install cocoapods
       shell: bash

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -28,6 +28,10 @@ runs:
       shell: bash
       run: brew install mint
 
+    - name: Install swift lint
+      shell: bash
+      run: brew install swiftlint
+
     - name: Bootstrap mint packages
       shell: bash
       run: mint bootstrap

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 **Requirements**
 
 - [ ] I have added test coverage for new or changed functionality
-- [ ] I have followed the repository's [pull request submission guidelines](../blob/v9/CONTRIBUTING.md#submitting-pull-requests)
+- [ ] I have followed the repository's [pull request submission guidelines](../blob/v11/CONTRIBUTING.md#submitting-pull-requests)
 - [ ] I have validated my changes against all supported platform versions
 
 **Related issues**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode-version: 15.4.0
-            ios-sim: "platform=iOS Simulator,name=iPhone 15"
-            os: macos-14
+          - xcode-version: 26.3
+            ios-sim: "platform=iOS Simulator,name=iPhone 26"
+            os: macos-15
             run-contract-tests: true
-          - xcode-version: 15.0.1
+          - xcode-version: 15.4.1
             ios-sim: "platform=iOS Simulator,name=iPhone 15"
             os: macos-14
             run-contract-tests: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode-version: 26.3
-            ios-sim: "platform=iOS Simulator,name=iPhone 26"
+          - xcode-version: 16.4.0
+            ios-sim: "platform=iOS Simulator,name=iPhone 16"
             os: macos-15
             run-contract-tests: true
           - xcode-version: 15.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
             ios-sim: "platform=iOS Simulator,name=iPhone 26"
             os: macos-15
             run-contract-tests: true
-          - xcode-version: 15.4.1
+          - xcode-version: 15.4.0
             ios-sim: "platform=iOS Simulator,name=iPhone 15"
             os: macos-14
             run-contract-tests: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: Run CI
 on:
   push:
-    branches: [ v9, 'feat/**' ]
+    branches: [ v11, 'feat/**' ]
     paths-ignore:
       - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
-    branches: [ v9, 'feat/**' ]
+    branches: [ v11, 'feat/**' ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode-version: 15.0.1
-            ios-sim: 'platform=iOS Simulator,name=iPhone 15,OS=17.2'
-            os: macos-13
+          - xcode-version: 15.4.0
+            ios-sim: "platform=iOS Simulator,name=iPhone 17"
+            os: macos-14
             run-contract-tests: true
-          - xcode-version: 14.3.1
-            ios-sim: 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
-            os: macos-13
+          - xcode-version: 15.0.1
+            ios-sim: "platform=iOS Simulator,name=iPhone 17"
+            os: macos-14
             run-contract-tests: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         include:
           - xcode-version: 15.4.0
-            ios-sim: "platform=iOS Simulator,name=iPhone 17"
+            ios-sim: "platform=iOS Simulator,name=iPhone 15"
             os: macos-14
             run-contract-tests: true
           - xcode-version: 15.0.1
-            ios-sim: "platform=iOS Simulator,name=iPhone 17"
+            ios-sim: "platform=iOS Simulator,name=iPhone 15"
             os: macos-14
             run-contract-tests: false
 

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Build and Test
         uses: ./.github/actions/ci
         with:
-          xcode-version: 26.3
-          ios-sim: "platform=iOS Simulator,name=iPhone 26"
+          xcode-version: 16.4.0
+          ios-sim: "platform=iOS Simulator,name=iPhone 16"
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/manual-publish-docs.yml
+++ b/.github/workflows/manual-publish-docs.yml
@@ -4,7 +4,7 @@ on:
 name: Publish Documentation
 jobs:
   build-publish:
-    runs-on: macos-14
+    runs-on: macos-15
 
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
@@ -16,8 +16,8 @@ jobs:
       - name: Build and Test
         uses: ./.github/actions/ci
         with:
-          xcode-version: 15.0.1
-          ios-sim: 'platform=iOS Simulator,name=iPhone 15,OS=17.2'
+          xcode-version: 26.3
+          ios-sim: "platform=iOS Simulator,name=iPhone 26"
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -27,8 +27,8 @@ jobs:
 
       - uses: ./.github/actions/ci
         with:
-          xcode-version: 15.0.1
-          ios-sim: 'platform=iOS Simulator,name=iPhone 15,OS=17.2'
+          xcode-version: 26.3
+          ios-sim: "platform=iOS Simulator,name=iPhone 26"
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -27,8 +27,8 @@ jobs:
 
       - uses: ./.github/actions/ci
         with:
-          xcode-version: 26.3
-          ios-sim: "platform=iOS Simulator,name=iPhone 26"
+          xcode-version: 16.4.0
+          ios-sim: "platform=iOS Simulator,name=iPhone 16"
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,8 +46,8 @@ jobs:
       - uses: ./.github/actions/ci
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
-          xcode-version: 15.0.1
-          ios-sim: 'platform=iOS Simulator,name=iPhone 15,OS=17.2'
+          xcode-version: 26.3
+          ios-sim: "platform=iOS Simulator,name=iPhone 26"
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,16 +38,16 @@ jobs:
       #
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        name: 'Get Cocoapods token'
+        name: "Get Cocoapods token"
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/cocoapods/token = COCOAPODS_TRUNK_TOKEN'
+          ssm_parameter_pairs: "/production/common/releasing/cocoapods/token = COCOAPODS_TRUNK_TOKEN"
 
       - uses: ./.github/actions/ci
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
-          xcode-version: 26.3
-          ios-sim: "platform=iOS Simulator,name=iPhone 26"
+          xcode-version: 16.4.0
+          ios-sim: "platform=iOS Simulator,name=iPhone 16"
           run-contract-tests: true
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - v9
+      - v11
 
 jobs:
   release-package:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -33,7 +33,7 @@ function_body_length:
 
 type_body_length:
   warning: 300
-  error: 500
+  error: 600
 
 file_length:
   warning: 1000

--- a/ContractTests/Package.swift
+++ b/ContractTests/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 

--- a/ContractTests/Package.swift
+++ b/ContractTests/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
     name: "ContractTests",
     platforms: [
-        .iOS(.v12),
-        .macOS(.v10_15),
-        .watchOS(.v4),
-        .tvOS(.v12)
+        .iOS(.v13),
+        .macOS(.v12),
+        .watchOS(.v6),
+        .tvOS(.v13)
     ],
     products: [
         .executable(

--- a/LaunchDarkly.xcodeproj/project.pbxproj
+++ b/LaunchDarkly.xcodeproj/project.pbxproj
@@ -249,6 +249,9 @@
 		A350387D2F4F5A380032BA9F /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350387B2F4F5A380032BA9F /* Data+Compression.swift */; };
 		A350387E2F4F5A380032BA9F /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350387B2F4F5A380032BA9F /* Data+Compression.swift */; };
 		A350387F2F4F5A380032BA9F /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350387B2F4F5A380032BA9F /* Data+Compression.swift */; };
+		A35038812F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038802F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift */; };
+		A35038832F4F96680032BA9F /* LDClientEvaluationHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038822F4F96680032BA9F /* LDClientEvaluationHookSpec.swift */; };
+		A35038852F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038842F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift */; };
 		A3570F5A28527B8200CF241A /* LDContextCodableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3570F5928527B8200CF241A /* LDContextCodableSpec.swift */; };
 		A358D6D12A4DD48600270C60 /* EnvironmentReporterChainBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A358D6D02A4DD48600270C60 /* EnvironmentReporterChainBase.swift */; };
 		A358D6D22A4DD48600270C60 /* EnvironmentReporterChainBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A358D6D02A4DD48600270C60 /* EnvironmentReporterChainBase.swift */; };
@@ -315,7 +318,6 @@
 		A3BA7CF42BD05A280000DB28 /* EvaluationSeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7CF22BD05A280000DB28 /* EvaluationSeriesContext.swift */; };
 		A3BA7CF52BD05A280000DB28 /* EvaluationSeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7CF22BD05A280000DB28 /* EvaluationSeriesContext.swift */; };
 		A3BA7CF62BD05A280000DB28 /* EvaluationSeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7CF22BD05A280000DB28 /* EvaluationSeriesContext.swift */; };
-		A3BA7D022BD192240000DB28 /* LDClientHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7D012BD192240000DB28 /* LDClientHookSpec.swift */; };
 		A3BA7D042BD2BD620000DB28 /* TestContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3BA7D032BD2BD620000DB28 /* TestContext.swift */; };
 		A3C6F7622B7FA803005B3B61 /* SheddingQueueSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C6F7612B7FA803005B3B61 /* SheddingQueueSpec.swift */; };
 		A3C6F7642B84EF0C005B3B61 /* IdentifyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C6F7632B84EF0C005B3B61 /* IdentifyTypes.swift */; };
@@ -533,6 +535,9 @@
 		A350386C2F4F4F610032BA9F /* IdentifySeriesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifySeriesContext.swift; sourceTree = "<group>"; };
 		A35038762F4F58660032BA9F /* LDClientIdentifyHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientIdentifyHook.swift; sourceTree = "<group>"; };
 		A350387B2F4F5A380032BA9F /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
+		A35038802F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientIdentifyHookSpec.swift; sourceTree = "<group>"; };
+		A35038822F4F96680032BA9F /* LDClientEvaluationHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientEvaluationHookSpec.swift; sourceTree = "<group>"; };
+		A35038842F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchOSEnvironmentReporterSpec.swift; sourceTree = "<group>"; };
 		A3570F5928527B8200CF241A /* LDContextCodableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDContextCodableSpec.swift; sourceTree = "<group>"; };
 		A358D6D02A4DD48600270C60 /* EnvironmentReporterChainBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentReporterChainBase.swift; sourceTree = "<group>"; };
 		A358D6D62A4DE6A500270C60 /* ApplicationInfoEnvironmentReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationInfoEnvironmentReporter.swift; sourceTree = "<group>"; };
@@ -552,7 +557,6 @@
 		A3BA7CE82BD056920000DB28 /* Hook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hook.swift; sourceTree = "<group>"; };
 		A3BA7CED2BD059180000DB28 /* Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
 		A3BA7CF22BD05A280000DB28 /* EvaluationSeriesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationSeriesContext.swift; sourceTree = "<group>"; };
-		A3BA7D012BD192240000DB28 /* LDClientHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientHookSpec.swift; sourceTree = "<group>"; };
 		A3BA7D032BD2BD620000DB28 /* TestContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestContext.swift; sourceTree = "<group>"; };
 		A3C6F7612B7FA803005B3B61 /* SheddingQueueSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheddingQueueSpec.swift; sourceTree = "<group>"; };
 		A3C6F7632B84EF0C005B3B61 /* IdentifyTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifyTypes.swift; sourceTree = "<group>"; };
@@ -756,8 +760,9 @@
 		8354EFCF1F22491C00C05156 /* LaunchDarklyTests */ = {
 			isa = PBXGroup;
 			children = (
+				A35038822F4F96680032BA9F /* LDClientEvaluationHookSpec.swift */,
+				A35038802F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift */,
 				3D2406242E0D90EA00F91253 /* LDClientPluginsSpec.swift */,
-				A3BA7D012BD192240000DB28 /* LDClientHookSpec.swift */,
 				838F96731FB9F024009CFC45 /* LDClientSpec.swift */,
 				3D9A12572A73236800698B8D /* UtilSpec.swift */,
 				83EF67911F9945CE00403126 /* Models */,
@@ -935,6 +940,7 @@
 		A3047D5B2A606A0000F568E0 /* EnvironmentReporting */ = {
 			isa = PBXGroup;
 			children = (
+				A35038842F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift */,
 				A3047D622A606B6000F568E0 /* ApplicationInfoEnvironmentReporterSpec.swift */,
 				A3047D5F2A606B6000F568E0 /* EnvironmentReporterChainBaseSpec.swift */,
 				A3047D5E2A606B6000F568E0 /* IOSEnvironmentReporterSpec.swift */,
@@ -1610,6 +1616,7 @@
 				8392FFA32033565700320914 /* HTTPURLResponse.swift in Sources */,
 				83411A5F1FABDA8700E5CF39 /* mocks.generated.swift in Sources */,
 				83DDBF001FA2589900E428B6 /* FlagStoreSpec.swift in Sources */,
+				A35038852F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift in Sources */,
 				B4F689142497B2FC004D3CE0 /* DiagnosticEventSpec.swift in Sources */,
 				83396BC91F7C3711000E256E /* DarklyServiceSpec.swift in Sources */,
 				3D9A12582A73236800698B8D /* UtilSpec.swift in Sources */,
@@ -1621,6 +1628,7 @@
 				838F96741FB9F024009CFC45 /* LDClientSpec.swift in Sources */,
 				83A0E6B1203B557F00224298 /* FeatureFlagSpec.swift in Sources */,
 				A31088282837DCA900184942 /* ReferenceSpec.swift in Sources */,
+				A35038832F4F96680032BA9F /* LDClientEvaluationHookSpec.swift in Sources */,
 				83EBCBB720DABE93003A7142 /* FlagRequestTrackerSpec.swift in Sources */,
 				B4265EB124E7390C001CFD2C /* TestUtil.swift in Sources */,
 				B46F344125E6DB7D0078D45F /* DiagnosticReporterSpec.swift in Sources */,
@@ -1639,6 +1647,7 @@
 				A3047D692A606B6000F568E0 /* ApplicationInfoEnvironmentReporterSpec.swift in Sources */,
 				3D3AB9482A570F3A003AECF1 /* ModifierSpec.swift in Sources */,
 				83383A5120460DD30024D975 /* SynchronizingErrorSpec.swift in Sources */,
+				A35038812F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift in Sources */,
 				83B9A080204F56F4000C3F17 /* FlagChangeObserverSpec.swift in Sources */,
 				830DB3AC22380A3E00D65D25 /* HTTPHeadersSpec.swift in Sources */,
 				831425AF206ABB5300F2EF36 /* EnvironmentReportingMock.swift in Sources */,
@@ -1648,7 +1657,6 @@
 				50EE85C72EA0749C007CC662 /* TimeoutExecutorSpec.swift in Sources */,
 				837406D421F760640087B22B /* LDTimerSpec.swift in Sources */,
 				832307A61F7D8D720029815A /* URLRequestSpec.swift in Sources */,
-				A3BA7D022BD192240000DB28 /* LDClientHookSpec.swift in Sources */,
 				832307A81F7DA61B0029815A /* LDEventSourceMock.swift in Sources */,
 				838F967A1FBA551A009CFC45 /* ClientServiceMockFactory.swift in Sources */,
 				A31088292837DCA900184942 /* KindSpec.swift in Sources */,

--- a/LaunchDarkly/GeneratedCode/mocks.generated.swift
+++ b/LaunchDarkly/GeneratedCode/mocks.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.2.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Foundation

--- a/LaunchDarkly/LaunchDarkly/Extensions/Data+Compression.swift
+++ b/LaunchDarkly/LaunchDarkly/Extensions/Data+Compression.swift
@@ -29,6 +29,8 @@ import Foundation
 import Compression
 
 public extension Data {
+    /// Compresses the data using the gzip algorithm.
+    /// - returns: gzip compressed data, or nil if compression fails
     @inline(__always)
     func ld_gzip() -> Data? {
         gzip()
@@ -180,6 +182,7 @@ internal extension Data {
         let overhead = 10 + 8
         guard count >= overhead else { return nil }
 
+        // swiftlint:disable:next large_tuple
         typealias GZipHeader = (id1: UInt8, id2: UInt8, cm: UInt8, flg: UInt8, xfl: UInt8, os: UInt8)
         let hdr: GZipHeader = withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> GZipHeader in
             // +---+---+---+---+---+---+---+---+---+---+
@@ -200,28 +203,28 @@ internal extension Data {
         // Wrong gzip magic or unsupported compression method
         guard hdr.id1 == 0x1f && hdr.id2 == 0x8b && hdr.cm == 0x08 else { return nil }
 
-        let has_crc16: Bool = hdr.flg & 0b00010 != 0
-        let has_extra: Bool = hdr.flg & 0b00100 != 0
-        let has_fname: Bool = hdr.flg & 0b01000 != 0
-        let has_cmmnt: Bool = hdr.flg & 0b10000 != 0
+        let hasCrc16: Bool = hdr.flg & 0b00010 != 0
+        let hasExtra: Bool = hdr.flg & 0b00100 != 0
+        let hasFname: Bool = hdr.flg & 0b01000 != 0
+        let hasCmmnt: Bool = hdr.flg & 0b10000 != 0
 
         let cresult: Data? = withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> Data? in
             var pos = 10 ; let limit = count - 8
 
-            if has_extra {
+            if hasExtra {
                 pos += ptr.advanced(by: pos).withMemoryRebound(to: UInt16.self, capacity: 1) {
                     return Int($0.pointee.littleEndian) + 2 // +2 for xlen
                 }
             }
-            if has_fname {
+            if hasFname {
                 while pos < limit && ptr[pos] != 0x0 { pos += 1 }
                 pos += 1 // skip null byte as well
             }
-            if has_cmmnt {
+            if hasCmmnt {
                 while pos < limit && ptr[pos] != 0x0 { pos += 1 }
                 pos += 1 // skip null byte as well
             }
-            if has_crc16 {
+            if hasCrc16 {
                 pos += 2 // ignoring header crc16
             }
 

--- a/LaunchDarkly/LaunchDarkly/Extensions/Data+Compression.swift
+++ b/LaunchDarkly/LaunchDarkly/Extensions/Data+Compression.swift
@@ -7,7 +7,6 @@
 ///  Created by Markus Wanke, 2016/12/05
 ///
 
-
 ///
 ///                Apache License, Version 2.0
 ///
@@ -26,7 +25,6 @@
 ///  limitations under the License.
 ///
 
-
 import Foundation
 import Compression
 
@@ -38,161 +36,150 @@ public extension Data {
 }
 
 // equal to .package(name: "DataCompression", url: "https://github.com/mw99/DataCompression", .exact("3.9.0")) with removed publics
-internal extension Data
-{
+internal extension Data {
     /// Compresses the data.
     /// - parameter withAlgorithm: Compression algorithm to use. See the `CompressionAlgorithm` type
     /// - returns: compressed data
-    func compress(withAlgorithm algo: CompressionAlgorithm) -> Data?
-    {
+    func compress(withAlgorithm algo: CompressionAlgorithm) -> Data? {
         return self.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
             let config = (operation: COMPRESSION_STREAM_ENCODE, algorithm: algo.lowLevelType)
             return perform(config, source: sourcePtr, sourceSize: count)
         }
     }
-    
+
     /// Decompresses the data.
     /// - parameter withAlgorithm: Compression algorithm to use. See the `CompressionAlgorithm` type
     /// - returns: decompressed data
-    func decompress(withAlgorithm algo: CompressionAlgorithm) -> Data?
-    {
+    func decompress(withAlgorithm algo: CompressionAlgorithm) -> Data? {
         return self.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
             let config = (operation: COMPRESSION_STREAM_DECODE, algorithm: algo.lowLevelType)
             return perform(config, source: sourcePtr, sourceSize: count)
         }
     }
-    
+
     /// Please consider the [libcompression documentation](https://developer.apple.com/reference/compression/1665429-data_compression)
     /// for further details. Short info:
     /// zlib  : Aka deflate. Fast with a good compression rate. Proved itself over time and is supported everywhere.
     /// lzfse : Apples custom Lempel-Ziv style compression algorithm. Claims to compress as good as zlib but 2 to 3 times faster.
     /// lzma  : Horribly slow. Compression as well as decompression. Compresses better than zlib though.
     /// lz4   : Fast, but compression rate is very bad. Apples lz4 implementation often to not compress at all.
-    enum CompressionAlgorithm
-    {
+    enum CompressionAlgorithm {
         case zlib
         case lzfse
         case lzma
         case lz4
     }
-    
+
     /// Compresses the data using the zlib deflate algorithm.
     /// - returns: raw deflated data according to [RFC-1951](https://tools.ietf.org/html/rfc1951).
     /// - note: Fixed at compression level 5 (best trade off between speed and time)
-    func deflate() -> Data?
-    {
+    func deflate() -> Data? {
         return self.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
             let config = (operation: COMPRESSION_STREAM_ENCODE, algorithm: COMPRESSION_ZLIB)
             return perform(config, source: sourcePtr, sourceSize: count)
         }
     }
-    
+
     /// Decompresses the data using the zlib deflate algorithm. Self is expected to be a raw deflate
     /// stream according to [RFC-1951](https://tools.ietf.org/html/rfc1951).
     /// - returns: uncompressed data
-    func inflate() -> Data?
-    {
+    func inflate() -> Data? {
         return self.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
             let config = (operation: COMPRESSION_STREAM_DECODE, algorithm: COMPRESSION_ZLIB)
             return perform(config, source: sourcePtr, sourceSize: count)
         }
     }
-    
+
     /// Compresses the data using the deflate algorithm and makes it comply to the zlib format.
     /// - returns: deflated data in zlib format [RFC-1950](https://tools.ietf.org/html/rfc1950)
     /// - note: Fixed at compression level 5 (best trade off between speed and time)
-    func zip() -> Data?
-    {
+    func zip() -> Data? {
         let header = Data([0x78, 0x5e])
-        
+
         let deflated = self.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
             let config = (operation: COMPRESSION_STREAM_ENCODE, algorithm: COMPRESSION_ZLIB)
             return perform(config, source: sourcePtr, sourceSize: count, preload: header)
         }
-        
+
         guard var result = deflated else { return nil }
-        
+
         var adler = self.adler32().checksum.bigEndian
         result.append(Data(bytes: &adler, count: MemoryLayout<UInt32>.size))
-        
+
         return result
     }
-    
+
     /// Decompresses the data using the zlib deflate algorithm. Self is expected to be a zlib deflate
     /// stream according to [RFC-1950](https://tools.ietf.org/html/rfc1950).
     /// - returns: uncompressed data
-    func unzip(skipCheckSumValidation: Bool = true) -> Data?
-    {
+    func unzip(skipCheckSumValidation: Bool = true) -> Data? {
         // 2 byte header + 4 byte adler32 checksum
         let overhead = 6
         guard count > overhead else { return nil }
-        
+
         let header: UInt16 = withUnsafeBytes { (ptr: UnsafePointer<UInt16>) -> UInt16 in
             return ptr.pointee.bigEndian
         }
-        
+
         // check for the deflate stream bit
         guard header >> 8 & 0b1111 == 0b1000 else { return nil }
         // check the header checksum
         guard header % 31 == 0 else { return nil }
-        
+
         let cresult: Data? = withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> Data? in
             let source = ptr.advanced(by: 2)
             let config = (operation: COMPRESSION_STREAM_DECODE, algorithm: COMPRESSION_ZLIB)
             return perform(config, source: source, sourceSize: count - overhead)
         }
-        
+
         guard let inflated = cresult else { return nil }
-        
+
         if skipCheckSumValidation { return inflated }
-        
+
         let cksum = Data(self.suffix(from: count - 4)).withUnsafeBytes { rawPtr in
             return rawPtr.load(as: UInt32.self).bigEndian
         }
-        
+
         return cksum == inflated.adler32().checksum ? inflated : nil
     }
-    
+
     /// Compresses the data using the deflate algorithm and makes it comply to the gzip stream format.
     /// - returns: deflated data in gzip format [RFC-1952](https://tools.ietf.org/html/rfc1952)
     /// - note: Fixed at compression level 5 (best trade off between speed and time)
-    func gzip() -> Data?
-    {
+    func gzip() -> Data? {
         var header = Data([0x1f, 0x8b, 0x08, 0x00]) // magic, magic, deflate, noflags
-        
+
         var unixtime = UInt32(Date().timeIntervalSince1970).littleEndian
         header.append(Data(bytes: &unixtime, count: MemoryLayout<UInt32>.size))
-        
+
         header.append(contentsOf: [0x00, 0x03])  // normal compression level, unix file type
-        
+
         let deflated = self.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
             let config = (operation: COMPRESSION_STREAM_ENCODE, algorithm: COMPRESSION_ZLIB)
             return perform(config, source: sourcePtr, sourceSize: count, preload: header)
         }
-        
+
         guard var result = deflated else { return nil }
-        
+
         // append checksum
         var crc32: UInt32 = self.crc32().checksum.littleEndian
         result.append(Data(bytes: &crc32, count: MemoryLayout<UInt32>.size))
-        
+
         // append size of original data
         var isize: UInt32 = UInt32(truncatingIfNeeded: count).littleEndian
         result.append(Data(bytes: &isize, count: MemoryLayout<UInt32>.size))
-        
+
         return result
     }
-    
+
     /// Decompresses the data using the gzip deflate algorithm. Self is expected to be a gzip deflate
     /// stream according to [RFC-1952](https://tools.ietf.org/html/rfc1952).
     /// - returns: uncompressed data
-    func gunzip() -> Data?
-    {
+    func gunzip() -> Data? {
         // 10 byte header + data + 8 byte footer. See https://tools.ietf.org/html/rfc1952#section-2
         let overhead = 10 + 8
         guard count >= overhead else { return nil }
-        
-        
+
         typealias GZipHeader = (id1: UInt8, id2: UInt8, cm: UInt8, flg: UInt8, xfl: UInt8, os: UInt8)
         let hdr: GZipHeader = withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> GZipHeader in
             // +---+---+---+---+---+---+---+---+---+---+
@@ -200,7 +187,7 @@ internal extension Data
             // +---+---+---+---+---+---+---+---+---+---+
             return (id1: ptr[0], id2: ptr[1], cm: ptr[2], flg: ptr[3], xfl: ptr[8], os: ptr[9])
         }
-        
+
         typealias GZipFooter = (crc32: UInt32, isize: UInt32)
         let alignedFtr = Data(self.suffix(from: count - 8))
         let ftr: GZipFooter = alignedFtr.withUnsafeBytes { (ptr: UnsafePointer<UInt32>) -> GZipFooter in
@@ -209,18 +196,18 @@ internal extension Data
             // +---+---+---+---+---+---+---+---+
             return (ptr[0].littleEndian, ptr[1].littleEndian)
         }
-        
+
         // Wrong gzip magic or unsupported compression method
         guard hdr.id1 == 0x1f && hdr.id2 == 0x8b && hdr.cm == 0x08 else { return nil }
-        
+
         let has_crc16: Bool = hdr.flg & 0b00010 != 0
         let has_extra: Bool = hdr.flg & 0b00100 != 0
         let has_fname: Bool = hdr.flg & 0b01000 != 0
         let has_cmmnt: Bool = hdr.flg & 0b10000 != 0
-        
+
         let cresult: Data? = withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> Data? in
             var pos = 10 ; let limit = count - 8
-            
+
             if has_extra {
                 pos += ptr.advanced(by: pos).withMemoryRebound(to: UInt16.self, capacity: 1) {
                     return Int($0.pointee.littleEndian) + 2 // +2 for xlen
@@ -237,97 +224,86 @@ internal extension Data
             if has_crc16 {
                 pos += 2 // ignoring header crc16
             }
-            
+
             guard pos < limit else { return nil }
             let config = (operation: COMPRESSION_STREAM_DECODE, algorithm: COMPRESSION_ZLIB)
             return perform(config, source: ptr.advanced(by: pos), sourceSize: limit - pos)
         }
-        
+
         guard let inflated = cresult                                   else { return nil }
         guard ftr.isize == UInt32(truncatingIfNeeded: inflated.count)  else { return nil }
         guard ftr.crc32 == inflated.crc32().checksum                   else { return nil }
         return inflated
     }
-    
+
     /// Calculate the Adler32 checksum of the data.
     /// - returns: Adler32 checksum type. Can still be further advanced.
-    func adler32() -> Adler32
-    {
+    func adler32() -> Adler32 {
         var res = Adler32()
         res.advance(withChunk: self)
         return res
     }
-    
+
     /// Calculate the Crc32 checksum of the data.
     /// - returns: Crc32 checksum type. Can still be further advanced.
-    func crc32() -> Crc32
-    {
+    func crc32() -> Crc32 {
         var res = Crc32()
         res.advance(withChunk: self)
         return res
     }
 }
 
-
-
-
 /// Struct based type representing a Crc32 checksum.
-struct Crc32: CustomStringConvertible
-{
+struct Crc32: CustomStringConvertible {
     private static let zLibCrc32: ZLibCrc32FuncPtr? = loadCrc32fromZLib()
-    
+
     init() {}
-    
+
     // C convention function pointer type matching the signature of `libz::crc32`
     private typealias ZLibCrc32FuncPtr = @convention(c) (
-        _ cks:  UInt32,
-        _ buf:  UnsafePointer<UInt8>,
-        _ len:  UInt32
+        _ cks: UInt32,
+        _ buf: UnsafePointer<UInt8>,
+        _ len: UInt32
     ) -> UInt32
-    
+
     /// Raw checksum. Updated after a every call to `advance(withChunk:)`
     var checksum: UInt32 = 0
-    
+
     /// Advance the current checksum with a chunk of data. Designed t be called multiple times.
     /// - parameter chunk: data to advance the checksum
-    mutating func advance(withChunk chunk: Data)
-    {
+    mutating func advance(withChunk chunk: Data) {
         if let fastCrc32 = Crc32.zLibCrc32 {
-            checksum = chunk.withUnsafeBytes({ (ptr: UnsafePointer<UInt8>) -> UInt32 in
+            checksum = chunk.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> UInt32 in
                 return fastCrc32(checksum, ptr, UInt32(chunk.count))
-            })
-        }
-        else {
+            }
+        } else {
             checksum = slowCrc32(start: checksum, data: chunk)
         }
     }
-    
+
     /// Formatted checksum.
-    var description: String
-    {
+    var description: String {
         return String(format: "%08x", checksum)
     }
-    
+
     /// Load `crc32()` from '/usr/lib/libz.dylib' if libz is installed.
     /// - returns: A function pointer to crc32() of zlib or nil if zlib can't be found
-    private static func loadCrc32fromZLib() -> ZLibCrc32FuncPtr?
-    {
+    private static func loadCrc32fromZLib() -> ZLibCrc32FuncPtr? {
         guard let libz = dlopen("/usr/lib/libz.dylib", RTLD_NOW) else { return nil }
         guard let fptr = dlsym(libz, "crc32") else { return nil }
         return unsafeBitCast(fptr, to: ZLibCrc32FuncPtr.self)
     }
-    
+
     /// Rudimentary fallback implementation of the crc32 checksum. This is only a backup used
     /// when zlib can't be found under '/usr/lib/libz.dylib'.
     /// - returns: crc32 checksum (4 byte)
-    private func slowCrc32(start: UInt32, data: Data) -> UInt32
-    {
+    private func slowCrc32(start: UInt32, data: Data) -> UInt32 {
         return ~data.reduce(~start) { (crc: UInt32, next: UInt8) -> UInt32 in
             let tableOffset = (crc ^ UInt32(next)) & 0xff
             return lookUpTable[Int(tableOffset)] ^ crc >> 8
         }
     }
-    
+
     /// Lookup table for faster crc32 calculation.
     /// table source: http://web.mit.edu/freebsd/head/sys/libkern/crc32.c
     private let lookUpTable: [UInt32] = [
@@ -362,69 +338,59 @@ struct Crc32: CustomStringConvertible
         0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2, 0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db,
         0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
         0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
-        0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d,
+        0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
     ]
 }
 
-
-
-
-
 /// Struct based type representing a Adler32 checksum.
-struct Adler32: CustomStringConvertible
-{
+struct Adler32: CustomStringConvertible {
     private static let zLibAdler32: ZLibAdler32FuncPtr? = loadAdler32fromZLib()
-    
+
     init() {}
-    
+
     // C convention function pointer type matching the signature of `libz::adler32`
     private typealias ZLibAdler32FuncPtr = @convention(c) (
-        _ cks:  UInt32,
-        _ buf:  UnsafePointer<UInt8>,
-        _ len:  UInt32
+        _ cks: UInt32,
+        _ buf: UnsafePointer<UInt8>,
+        _ len: UInt32
     ) -> UInt32
-    
+
     /// Raw checksum. Updated after a every call to `advance(withChunk:)`
     var checksum: UInt32 = 1
-    
+
     /// Advance the current checksum with a chunk of data. Designed t be called multiple times.
     /// - parameter chunk: data to advance the checksum
-    mutating func advance(withChunk chunk: Data)
-    {
+    mutating func advance(withChunk chunk: Data) {
         if let fastAdler32 = Adler32.zLibAdler32 {
-            checksum = chunk.withUnsafeBytes({ (ptr: UnsafePointer<UInt8>) -> UInt32 in
+            checksum = chunk.withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> UInt32 in
                 return fastAdler32(checksum, ptr, UInt32(chunk.count))
-            })
-        }
-        else {
+            }
+        } else {
             checksum = slowAdler32(start: checksum, data: chunk)
         }
     }
-    
+
     /// Formatted checksum.
-    var description: String
-    {
+    var description: String {
         return String(format: "%08x", checksum)
     }
-    
+
     /// Load `adler32()` from '/usr/lib/libz.dylib' if libz is installed.
     /// - returns: A function pointer to adler32() of zlib or nil if zlib can't be found
-    private static func loadAdler32fromZLib() -> ZLibAdler32FuncPtr?
-    {
+    private static func loadAdler32fromZLib() -> ZLibAdler32FuncPtr? {
         guard let libz = dlopen("/usr/lib/libz.dylib", RTLD_NOW) else { return nil }
         guard let fptr = dlsym(libz, "adler32") else { return nil }
         return unsafeBitCast(fptr, to: ZLibAdler32FuncPtr.self)
     }
-    
+
     /// Rudimentary fallback implementation of the adler32 checksum. This is only a backup used
     /// when zlib can't be found under '/usr/lib/libz.dylib'.
     /// - returns: adler32 checksum (4 byte)
-    private func slowAdler32(start: UInt32, data: Data) -> UInt32
-    {
+    private func slowAdler32(start: UInt32, data: Data) -> UInt32 {
         var s1: UInt32 = start & 0xffff
         var s2: UInt32 = (start >> 16) & 0xffff
         let prime: UInt32 = 65521
-        
+
         for byte in data {
             s1 += UInt32(byte)
             if s1 >= prime { s1 = s1 % prime }
@@ -435,67 +401,59 @@ struct Adler32: CustomStringConvertible
     }
 }
 
-
-
-fileprivate extension Data
-{
-    func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType
-    {
-        return try self.withUnsafeBytes({ (rawBufferPointer: UnsafeRawBufferPointer) -> ResultType in
+fileprivate extension Data {
+    func withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
+        return try self.withUnsafeBytes { (rawBufferPointer: UnsafeRawBufferPointer) -> ResultType in
             return try body(rawBufferPointer.bindMemory(to: ContentType.self).baseAddress!)
-        })
-    }
-}
-
-fileprivate extension Data.CompressionAlgorithm
-{
-    var lowLevelType: compression_algorithm {
-        switch self {
-        case .zlib    : return COMPRESSION_ZLIB
-        case .lzfse   : return COMPRESSION_LZFSE
-        case .lz4     : return COMPRESSION_LZ4
-        case .lzma    : return COMPRESSION_LZMA
         }
     }
 }
 
+fileprivate extension Data.CompressionAlgorithm {
+    var lowLevelType: compression_algorithm {
+        switch self {
+        case .zlib: return COMPRESSION_ZLIB
+        case .lzfse: return COMPRESSION_LZFSE
+        case .lz4: return COMPRESSION_LZ4
+        case .lzma: return COMPRESSION_LZMA
+        }
+    }
+}
 
-fileprivate typealias Config = (operation: compression_stream_operation, algorithm: compression_algorithm)
+private typealias Config = (operation: compression_stream_operation, algorithm: compression_algorithm)
 
-
-fileprivate func perform(_ config: Config, source: UnsafePointer<UInt8>, sourceSize: Int, preload: Data = Data()) -> Data?
-{
+private func perform(_ config: Config, source: UnsafePointer<UInt8>, sourceSize: Int, preload: Data = Data()) -> Data? {
     guard config.operation == COMPRESSION_STREAM_ENCODE || sourceSize > 0 else { return nil }
-    
+
     let mutableSource = UnsafeMutablePointer(mutating: source)
     var stream = compression_stream(dst_ptr: mutableSource, dst_size: 0, src_ptr: source, src_size: sourceSize, state: mutableSource)
-    
+
     let status = compression_stream_init(&stream, config.operation, config.algorithm)
     guard status != COMPRESSION_STATUS_ERROR else { return nil }
     defer { compression_stream_destroy(&stream) }
-    
+
     var result = preload
     var flags: Int32 = Int32(COMPRESSION_STREAM_FINALIZE.rawValue)
     let blockLimit = 64 * 1024
     var bufferSize = Swift.max(sourceSize, 64)
-    
+
     if sourceSize > blockLimit {
         bufferSize = blockLimit
-        if config.algorithm == COMPRESSION_LZFSE && config.operation != COMPRESSION_STREAM_ENCODE   {
+        if config.algorithm == COMPRESSION_LZFSE && config.operation != COMPRESSION_STREAM_ENCODE {
             // This fixes a bug in Apples lzfse decompressor. it will sometimes fail randomly when the input gets
             // splitted into multiple chunks and the flag is not 0. Even though it should always work with FINALIZE...
             flags = 0
         }
     }
-    
+
     let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
     defer { buffer.deallocate() }
-    
+
     stream.dst_ptr  = buffer
     stream.dst_size = bufferSize
     stream.src_ptr  = source
     stream.src_size = sourceSize
-    
+
     while true {
         switch compression_stream_process(&stream, flags) {
         case COMPRESSION_STATUS_OK:
@@ -503,15 +461,15 @@ fileprivate func perform(_ config: Config, source: UnsafePointer<UInt8>, sourceS
             result.append(buffer, count: stream.dst_ptr - buffer)
             stream.dst_ptr = buffer
             stream.dst_size = bufferSize
-            
+
             if flags == 0 && stream.src_size == 0 { // part of the lzfse bugfix above
                 flags = Int32(COMPRESSION_STREAM_FINALIZE.rawValue)
             }
-            
+
         case COMPRESSION_STATUS_END:
             result.append(buffer, count: stream.dst_ptr - buffer)
             return result
-            
+
         default:
             return nil
         }

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -296,7 +296,7 @@ public class LDClient {
     */
     @available(*, deprecated, message: "Use LDClient.identify(context: completion:) with non-optional completion parameter")
     public func identify(context: LDContext, completion: (() -> Void)? = nil) {
-        _identifyHooked(context: context, sheddable: false, useCache: .yes, timeout: 0) { _ in
+        identifyHooked(context: context, sheddable: false, useCache: .yes, timeout: 0) { _ in
             if let completion = completion {
                 DispatchQueue.main.async {
                     completion()
@@ -323,7 +323,7 @@ public class LDClient {
      - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
      */
     public func identify(context: LDContext, completion: @escaping (_ result: IdentifyResult) -> Void) {
-        _identifyHooked(context: context, sheddable: true, useCache: .yes, timeout: 0) { result in
+        identifyHooked(context: context, sheddable: true, useCache: .yes, timeout: 0) { result in
             DispatchQueue.main.async {
                 completion(result)
             }
@@ -343,7 +343,7 @@ public class LDClient {
      - parameter completion: Closure called when the embedded `setOnlineIdentify` call completes, subject to throttling delays.
      */
     public func identify(context: LDContext, useCache: IdentifyCacheUsage, completion: @escaping (_ result: IdentifyResult) -> Void) {
-        _identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: 0) { result in
+        identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: 0) { result in
             DispatchQueue.main.async {
                 completion(result)
             }
@@ -352,7 +352,7 @@ public class LDClient {
 
     // Temporary helper method to allow code sharing between the sheddable and unsheddable identify methods. In the next major release, we will remove the deprecated identify method and inline
     // this implementation in the other one.
-    func _identify(context: LDContext, sheddable: Bool, useCache: IdentifyCacheUsage, completion: @escaping (_ result: IdentifyResult) -> Void) {
+    func identifyImpl(context: LDContext, sheddable: Bool, useCache: IdentifyCacheUsage, completion: @escaping (_ result: IdentifyResult) -> Void) {
         let work: TaskHandler = { taskCompletion in
             let dispatch = DispatchGroup()
 
@@ -409,7 +409,7 @@ public class LDClient {
             os_log("%s LDClient.identify was called with a timeout greater than %f seconds. We recommend a timeout of less than %f seconds.", log: config.logger, type: .info, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
         }
 
-        self._identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: timeout) { result in
+        self.identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: timeout) { result in
             DispatchQueue.main.async {
                 completion(result)
             }

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -372,7 +372,7 @@ public class LDClient {
         }
         identifyQueue.enqueue(request: identifyTask)
     }
-    
+
     /**
      Sets the LDContext into the LDClient inline with the behavior detailed on `LDClient.identify(context: completion:)`. Additionally,
      this method will ensure the `completion` parameter will be called within the specified time interval.
@@ -408,7 +408,7 @@ public class LDClient {
         if timeout > LDClient.longTimeoutInterval {
             os_log("%s LDClient.identify was called with a timeout greater than %f seconds. We recommend a timeout of less than %f seconds.", log: config.logger, type: .info, self.typeName(and: #function), LDClient.longTimeoutInterval, LDClient.longTimeoutInterval)
         }
-        
+
         self._identifyHooked(context: context, sheddable: true, useCache: useCache, timeout: timeout) { result in
             DispatchQueue.main.async {
                 completion(result)

--- a/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
@@ -41,14 +41,14 @@ extension LDClient {
         }
     }
 
-    func _identifyHooked(context: LDContext, sheddable: Bool, useCache: IdentifyCacheUsage, timeout: TimeInterval, completion: @escaping (_ result: IdentifyResult) -> Void) {
+    func identifyHooked(context: LDContext, sheddable: Bool, useCache: IdentifyCacheUsage, timeout: TimeInterval, completion: @escaping (_ result: IdentifyResult) -> Void) {
         if timeout > 0 {
             executeWithIdentifyHooks(context: context) { hooksCompletion in
                 TimeoutExecutor.run(
                     timeout: timeout,
                     queue: .global(),
                     operation: { [weak self] done in
-                        self?._identify(context: context, sheddable: sheddable, useCache: useCache) { result in
+                        self?.identifyImpl(context: context, sheddable: sheddable, useCache: useCache) { result in
                             done(result)
                         }
                     },
@@ -60,7 +60,7 @@ extension LDClient {
             }
         } else {
             executeWithIdentifyHooks(context: context) { [weak self] hooksCompletion in
-                self?._identify(context: context, sheddable: sheddable, useCache: useCache) { result in
+                self?.identifyImpl(context: context, sheddable: sheddable, useCache: useCache) { result in
                     completion(result)
                     hooksCompletion(result)
                 }

--- a/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
@@ -6,22 +6,22 @@ extension LDClient {
         let seriesData: [IdentifySeriesData]
         let hooksSnapshot: [Hook]
     }
-    
+
     private func executeWithIdentifyHooks(context: LDContext, work: @escaping ((@escaping (IdentifyResult) -> Void)) -> Void) {
         let state = executeBeforeIdentifyHooks(context: context)
-        work() { [weak self] result in
+        work { [weak self] result in
             guard let state else {
                 return
             }
             self?.executeAfterIdentifyHooks(state: state, result: result)
         }
     }
-    
+
     private func executeBeforeIdentifyHooks(context: LDContext) -> IdentifyHookState? {
         guard !hooks.isEmpty else {
             return nil
         }
-        
+
         let hooksSnapshot = self.hooks
         let seriesContext = IdentifySeriesContext(context: context, methodName: "identify")
         let seriesData = hooksSnapshot.map { hook in
@@ -29,18 +29,18 @@ extension LDClient {
         }
         return IdentifyHookState(seriesContext: seriesContext, seriesData: seriesData, hooksSnapshot: hooksSnapshot)
     }
-    
+
     private func executeAfterIdentifyHooks(state: IdentifyHookState, result: IdentifyResult) {
         guard !state.hooksSnapshot.isEmpty else {
             return
         }
-        
+
         // Invoke hooks in reverse order and give them back the series data they gave us.
         zip(state.hooksSnapshot, state.seriesData).reversed().forEach { (hook, data) in
             _ = hook.afterIdentify(seriesContext: state.seriesContext, seriesData: data, result: result)
         }
     }
-    
+
     func _identifyHooked(context: LDContext, sheddable: Bool, useCache: IdentifyCacheUsage, timeout: TimeInterval, completion: @escaping (_ result: IdentifyResult) -> Void) {
         if timeout > 0 {
             executeWithIdentifyHooks(context: context) { hooksCompletion in
@@ -52,12 +52,11 @@ extension LDClient {
                             done(result)
                         }
                     },
-                    timeoutValue: .timeout,
-                    completion: { result in
+                    timeoutValue: .timeout
+                )                    { result in
                         completion(result)
                         hooksCompletion(result)
                     }
-                )
             }
         } else {
             executeWithIdentifyHooks(context: context) { [weak self] hooksCompletion in

--- a/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
@@ -53,7 +53,7 @@ extension LDClient {
                         }
                     },
                     timeoutValue: .timeout
-                )                    { result in
+                ) { result in
                         completion(result)
                         hooksCompletion(result)
                     }

--- a/LaunchDarkly/LaunchDarkly/LDValueDecoder.swift
+++ b/LaunchDarkly/LaunchDarkly/LDValueDecoder.swift
@@ -11,7 +11,7 @@ import Foundation
  modifications were required as part of the updates.
  */
 
-//===----------------------------------------------------------------------===//
+// ===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -21,7 +21,7 @@ import Foundation
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
-//===----------------------------------------------------------------------===//
+// ===----------------------------------------------------------------------===//
 
 // Taken from https://github.com/apple/swift-corelibs-foundation/blob/dbca8c7ddcfd19f7f6f6e1b60fd3ee3f748e263c/Sources/Foundation/JSONEncoder.swift#L1186
 
@@ -58,7 +58,7 @@ internal struct LDValueKey: CodingKey {
 /// The marker protocol also provides access to the type of the `Decodable` values,
 /// which is needed for the implementation of the key conversion strategy exemption.
 ///
-fileprivate protocol _JSONStringDictionaryDecodableMarker {
+private protocol _JSONStringDictionaryDecodableMarker {
     static var elementType: Decodable.Type { get }
 }
 
@@ -68,9 +68,9 @@ extension Dictionary: _JSONStringDictionaryDecodableMarker where Key == String, 
 
 // Taken from https://github.com/apple/swift-corelibs-foundation/blob/dbca8c7ddcfd19f7f6f6e1b60fd3ee3f748e263c/Sources/Foundation/JSONDecoder.swift
 
-//===----------------------------------------------------------------------===//
+// ===----------------------------------------------------------------------===//
 // JSON Decoder
-//===----------------------------------------------------------------------===//
+// ===----------------------------------------------------------------------===//
 
 /// `LDValueDecoder` facilitates the decoding of LDValue into semantic `Decodable` types.
 class LDValueDecoder {
@@ -108,7 +108,7 @@ class LDValueDecoder {
 
 // MARK: - _LDValueDecoder
 
-fileprivate struct LDValueDecoderImpl {
+private struct LDValueDecoderImpl {
     let codingPath: [CodingKey]
     let userInfo: [CodingUserInfoKey: Any]
 
@@ -245,8 +245,7 @@ extension LDValueDecoderImpl: Decoder {
     private func unwrapFloatingPoint<T: LosslessStringConvertible & BinaryFloatingPoint>(
         from value: LDValue,
         for additionalKey: CodingKey? = nil,
-        as type: T.Type) throws -> T
-    {
+        as type: T.Type) throws -> T {
         if case .number(let number) = value {
             return T(number)
         }
@@ -257,8 +256,7 @@ extension LDValueDecoderImpl: Decoder {
     private func unwrapFixedWidthInteger<T: FixedWidthInteger>(
         from value: LDValue,
         for additionalKey: CodingKey? = nil,
-        as type: T.Type) throws -> T
-    {
+        as type: T.Type) throws -> T {
         guard case .number(let number) = value else {
             throw self.createTypeMismatchError(type: T.self, for: additionalKey, value: value)
         }
@@ -491,8 +489,7 @@ extension LDValueDecoderImpl {
         }
 
         func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws
-            -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey
-        {
+            -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
             try decoderForKey(key).container(keyedBy: type)
         }
 
@@ -678,8 +675,7 @@ extension LDValueDecoderImpl {
         }
 
         mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws
-            -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey
-        {
+            -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
             let decoder = try decoderForNextElement(ofType: KeyedDecodingContainer<NestedKey>.self)
             let container = try decoder.container(keyedBy: type)
 

--- a/LaunchDarkly/LaunchDarkly/Models/Context/Modifier.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Context/Modifier.swift
@@ -54,7 +54,7 @@ class AutoEnvContextModifier {
             ).base64UrlEncodedString
         }
 
-        var callables: [String : () -> LDValue] = [:]
+        var callables: [String: () -> LDValue] = [:]
         callables[AutoEnvContextModifier.envAttributesVersion] = { () -> LDValue in AutoEnvContextModifier.specVersion.toLDValue() }
         callables[AutoEnvContextModifier.attrId] = { () -> LDValue in self.environmentReporter.applicationInfo.applicationId?.toLDValue() ?? LDValue.null }
         callables[AutoEnvContextModifier.attrName] = { () -> LDValue in self.environmentReporter.applicationInfo.applicationName?.toLDValue() ?? LDValue.null }
@@ -84,7 +84,7 @@ class AutoEnvContextModifier {
             LDContext.defaultKey(kind: Kind(AutoEnvContextModifier.ldDeviceKind)!)
         }
 
-        var callables: [String : () -> LDValue] = [:]
+        var callables: [String: () -> LDValue] = [:]
         callables[AutoEnvContextModifier.envAttributesVersion] = { () -> LDValue in AutoEnvContextModifier.specVersion.toLDValue() }
         callables[AutoEnvContextModifier.attrManufacturer] = { () -> LDValue in self.environmentReporter.manufacturer.toLDValue() }
         callables[AutoEnvContextModifier.attrModel] = { () -> LDValue in self.environmentReporter.deviceModel.toLDValue() }
@@ -142,7 +142,7 @@ final class ContextRecipe {
     fileprivate let keyCallable: () -> String
     fileprivate let attributeCallables: [String: () -> LDValue]
 
-    init(kind: String, keyCallable: @escaping () -> String, attributeCallables: [String : () -> LDValue]) {
+    init(kind: String, keyCallable: @escaping () -> String, attributeCallables: [String: () -> LDValue]) {
         self.kind = kind
         self.keyCallable = keyCallable
         self.attributeCallables = attributeCallables

--- a/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagChange/LDChangedFlag.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/FeatureFlag/FlagChange/LDChangedFlag.swift
@@ -14,10 +14,4 @@ public struct LDChangedFlag {
     public let oldValue: LDValue
     /// The feature flag's value after the change.
     public let newValue: LDValue
-
-    init(key: LDFlagKey, oldValue: LDValue, newValue: LDValue) {
-        self.key = key
-        self.oldValue = oldValue
-        self.newValue = newValue
-    }
 }

--- a/LaunchDarkly/LaunchDarkly/Models/Hooks/EvaluationSeriesContext.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Hooks/EvaluationSeriesContext.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Contextual information that will be provided to handlers during evaluation series.
 public class EvaluationSeriesContext {
     /// The key of the flag being evaluated.

--- a/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
@@ -10,7 +10,7 @@ public typealias IdentifySeriesData = [String: Any]
 public protocol Hook {
     /// Get metadata about the hook implementation.
     func metadata() -> Metadata
-    
+
     /// Executed by the SDK at the start of the evaluation of a feature flag.
     ///
     /// This is not executed as part of a call to `LDClient.allFlags()`.
@@ -25,7 +25,7 @@ public protocol Hook {
     ///                 `beforeEvaluation` is the first stage in this series, so this will be an empty dictionary.
     /// - Returns: A dictionary containing custom data that will be carried through to the next stage of the series.
     func beforeEvaluation(seriesContext: EvaluationSeriesContext, seriesData: EvaluationSeriesData) -> EvaluationSeriesData
-    
+
     /// Executed by the SDK after the evaluation of a feature flag completes.
     ///
     /// This is not executed as part of a call to `LDClient.allFlags()`.
@@ -39,7 +39,7 @@ public protocol Hook {
     ///   - evaluationDetail: The result of the evaluation that took place before this hook was invoked.
     /// - Returns: A dictionary containing custom data that will be carried through to the next stage of the series (if added in the future).
     func afterEvaluation(seriesContext: EvaluationSeriesContext, seriesData: EvaluationSeriesData, evaluationDetail: LDEvaluationDetail<LDValue>) -> EvaluationSeriesData
-    
+
     /// To provide custom data to the series which will be given back to your Hook at the next stage of the series,
     /// return a dictionary containing the custom data. You should initialize this dictionary from the `seriesData`.
     ///
@@ -48,7 +48,7 @@ public protocol Hook {
     ///   - seriesData: A record associated with each stage of hook invocations. Each stage is called with the data of the previous stage for a series. The input record should not be modified.
     /// - Returns: A dictionary containing custom data that will be carried through to the next stage of the series.
     func beforeIdentify(seriesContext: IdentifySeriesContext, seriesData: IdentifySeriesData) -> IdentifySeriesData
-    
+
     /// Called during the execution of the identify process, after the operation completes.
     ///
     /// This is currently the last stage of the identify series in the Hook, but that may not be the case in the future.

--- a/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
@@ -4,6 +4,10 @@ import Foundation
 ///
 /// Hook implementations can use this to store data needed between stages.
 public typealias EvaluationSeriesData = [String: Any]
+
+/// Implementation specific hook data for identify stages.
+///
+/// Hook implementations can use this to store data needed between stages.
 public typealias IdentifySeriesData = [String: Any]
 
 /// Protocol for extending SDK functionality via hooks.

--- a/LaunchDarkly/LaunchDarkly/Networking/DarklyService.swift
+++ b/LaunchDarkly/LaunchDarkly/Networking/DarklyService.swift
@@ -2,6 +2,7 @@ import Foundation
 import LDSwiftEventSource
 import OSLog
 
+// swiftlint:disable:next large_tuple
 typealias ServiceResponse = (data: Data?, urlResponse: URLResponse?, error: Error?, etag: String?)
 typealias ServiceCompletionHandler = (ServiceResponse) -> Void
 

--- a/LaunchDarkly/LaunchDarkly/ObjectiveC/ObjcLDConfig.swift
+++ b/LaunchDarkly/LaunchDarkly/ObjectiveC/ObjcLDConfig.swift
@@ -172,7 +172,6 @@ public final class ObjcLDConfig: NSObject {
         set { config.wrapperName = newValue }
     }
 
-
     /// For use by wrapper libraries to report the version of the library in use. If the `wrapperName` has not been set this field will be ignored. Otherwise the verison strill will be included with the `wrapperName` in the "X-LaunchDarkly-Wrapper" header on requests to the LaunchDarkly servers.
     @objc public var wrapperVersion: String? {
         get { config.wrapperVersion }

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/SheddingQueue.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/SheddingQueue.swift
@@ -53,7 +53,7 @@ class SheddingQueue {
 
         guard let request = nextTask else { return }
 
-        request.work() { [self] in
+        request.work { [self] in
             request.completion(.complete)
 
             stateQueue.sync {

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/TimeoutExecutor.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/TimeoutExecutor.swift
@@ -39,7 +39,7 @@ final class TimeoutExecutor {
             }
             return
         }
-        
+
         let lockQueue = DispatchQueue(label: "launchdarkly.timeout.executor.lock")
         var finished = false
 
@@ -52,7 +52,7 @@ final class TimeoutExecutor {
                     shouldCall = true
                 }
             }
-            
+
             if shouldCall {
                 queue.async { completion(value) }
             }
@@ -67,7 +67,7 @@ final class TimeoutExecutor {
                     shouldCall = true
                 }
             }
-            
+
             if shouldCall {
                 completion(timeoutValue())
             }

--- a/LaunchDarkly/LaunchDarklyTests/Extensions/CompressionTest.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Extensions/CompressionTest.swift
@@ -1,48 +1,37 @@
-
 import XCTest
 
 @testable import LaunchDarkly
 
+extension Data {
+    func gzip_gunzip() -> Data? { return c_gzip()?.c_gunzip() }
 
-extension Data
-{
-    func gzip_gunzip()     -> Data? { return c_gzip()?.c_gunzip() }
-
-    func c_gzip()     -> Data? { let res: Data? = self.gzip();     XCTAssertNotNil(res, "\(#function) failed"); return res }
-    func c_gunzip()   -> Data? { let res: Data? = self.gunzip();   XCTAssertNotNil(res, "\(#function) failed"); return res }
+    func c_gzip() -> Data? { let res: Data? = self.gzip();     XCTAssertNotNil(res, "\(#function) failed"); return res }
+    func c_gunzip() -> Data? { let res: Data? = self.gunzip();   XCTAssertNotNil(res, "\(#function) failed"); return res }
 }
 
-
-extension String
-{
-    func gzip_gunzip()     -> Data? { return data(using: .ascii)?.gzip_gunzip() }
+extension String {
+    func gzip_gunzip() -> Data? { return data(using: .ascii)?.gzip_gunzip() }
 }
 
-
-class CompressionTest: XCTestCase
-{
+class CompressionTest: XCTestCase {
     static var blob16mb: Data!
 
-    override class func setUp()
-    {
+    override class func setUp() {
         super.setUp()
         let b = 1024 * 1024 * 16 // 16 MB
         let ints = [UInt32](repeating: 0, count: b / 4).map { _ in arc4random() }
         self.blob16mb = Data(bytes: ints, count: b)
     }
 
-    func testEmptyString()
-    {
+    func testEmptyString() {
         XCTAssertEqual(Data(), "".gzip_gunzip())
     }
 
-    func testEmptyData()
-    {
+    func testEmptyData() {
         XCTAssertEqual(Data(), Data().gzip_gunzip())
     }
 
-    func testCrc32()
-    {
+    func testCrc32() {
         var crc = Crc32()
         XCTAssertEqual(crc.checksum, 0x0)
         crc.advance(withChunk: "The quick brown ".data(using: .ascii)!)
@@ -50,26 +39,23 @@ class CompressionTest: XCTestCase
         crc.advance(withChunk: "the lazy dog.".data(using: .ascii)!)
         XCTAssertEqual(crc.checksum, 0x519025e9)
     }
-    
-    func testMiscSmall_gzip_gunzip()
-    {
+
+    func testMiscSmall_gzip_gunzip() {
         for i in 1...500 {
             let s = String(repeating: "a", count: i)
             XCTAssertEqual(s.data(using: .ascii), s.gzip_gunzip(), "Fails with: \(s)")
         }
     }
 
-    func testAsciiNumbers_gzip_gunzip()
-    {
+    func testAsciiNumbers_gzip_gunzip() {
         for i in 1...500 {
-            let r = sqrt(Double(i)) / .pi 
+            let r = sqrt(Double(i)) / .pi
             let s = String(repeating: "\(r)", count: i)
             XCTAssertEqual(s.data(using: .ascii), s.gzip_gunzip(), "Fails with: \(s)")
         }
     }
 
-    func testRandomDataChunks_gzip_gunzip()
-    {
+    func testRandomDataChunks_gzip_gunzip() {
         for i in 1...500 {
             let ints = [UInt32](repeating: 0, count: 1 + (i / 4)).map { _ in arc4random() }
             let data = Data(bytes: ints, count: i)
@@ -77,13 +63,11 @@ class CompressionTest: XCTestCase
         }
     }
 
-    func testRandomDataBlob_16MB_gzip_gunzip()
-    {
+    func testRandomDataBlob_16MB_gzip_gunzip() {
         XCTAssertEqual(CompressionTest.blob16mb, CompressionTest.blob16mb.gzip_gunzip())
     }
 
-    func testGzipCrcFail()
-    {
+    func testGzipCrcFail() {
         let b = 1024 * 16
         let ints = [UInt32](repeating: 0xcafeabee, count: b / 4)
         var zipped_blob = Data(bytes: ints, count: b).gzip()!
@@ -95,8 +79,7 @@ class CompressionTest: XCTestCase
         XCTAssertNil(zipped_blob.gunzip())
     }
 
-    func testGzipISizeFail()
-    {
+    func testGzipISizeFail() {
         let b = 1024 * 16
         let ints = [UInt32](repeating: 0xcafeabee, count: b / 4)
         var zipped_blob = Data(bytes: ints, count: b).gzip()!

--- a/LaunchDarkly/LaunchDarklyTests/LDClientIdentifyHookSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientIdentifyHookSpec.swift
@@ -20,7 +20,7 @@ final class LDClientIdentifyHookSpec: XCTestCase {
         testContext.subject.identify(context: LDContext.stub()) { _ in }
         expect(count).toEventually(equal(3))
     }
-    
+
     func testRegistrationWithTimeout() {
         var count = 0
         let hook = MockHook(before: { _, data in count += 1; return data }, after: { _, data, _ in count += 2; return data })

--- a/LaunchDarkly/LaunchDarklyTests/Models/Context/LDContextCodableSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/Context/LDContextCodableSpec.swift
@@ -46,7 +46,7 @@ final class LDContextCodableSpec: XCTestCase {
             let context = try JSONDecoder().decode(LDContext.self, from: Data(json.utf8))
             let jsonEncoder = JSONEncoder()
             jsonEncoder.outputFormatting = [.sortedKeys]
-            jsonEncoder.userInfo = [LDContext.UserInfoKeys.includePrivateAttributes:true,LDContext.UserInfoKeys.redactAttributes:false]
+            jsonEncoder.userInfo = [LDContext.UserInfoKeys.includePrivateAttributes: true, LDContext.UserInfoKeys.redactAttributes: false]
             let output = try jsonEncoder.encode(context)
             let outputJson = String(data: output, encoding: .utf8)
 

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-realm/SwiftLint@0.43.1
+realm/SwiftLint@0.56.2
 krzysztofzablocki/Sourcery@1.2.1

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-realm/SwiftLint@0.63.0
+realm/SwiftLint@0.56.2
 krzysztofzablocki/Sourcery@2.3.0

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-realm/SwiftLint@0.56.2
-krzysztofzablocki/Sourcery@1.2.1
+realm/SwiftLint@0.63.0
+krzysztofzablocki/Sourcery@2.3.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LaunchDarkly SDK for iOS
 ========================
 
-[![Run CI](https://github.com/launchdarkly/ios-client-sdk/actions/workflows/ci.yml/badge.svg?branch=v9)](https://github.com/launchdarkly/ios-client-sdk/actions/workflows/ci.yml)
+[![Run CI](https://github.com/launchdarkly/ios-client-sdk/actions/workflows/ci.yml/badge.svg?branch=v11)](https://github.com/launchdarkly/ios-client-sdk/actions/workflows/ci.yml)
 [![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)
 [![CocoaPods compatible](https://img.shields.io/cocoapods/v/LaunchDarkly.svg)](https://cocoapods.org/pods/LaunchDarkly)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: Update github actions to reference correct branch
chore: Bump xcode versions under test
chore: Bump platform targets in contract tests
chore: Add missing spec files to project file
chore: Updated linter and fixed new issues
END_COMMIT_OVERRIDE

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because CI/build/release workflows are retargeted to `v11` and upgraded to newer macOS/Xcode/Swift toolchains, which can surface new build/lint/test failures. Runtime SDK logic changes appear minimal and largely refactoring/formatting plus test adjustments.
> 
> **Overview**
> Updates GitHub workflows/templates to reference the `v11` branch and modernizes CI runners/tooling (macOS 14/15, Xcode 15.4/16.4, iPhone 15/16 simulators), including adding explicit `swiftlint` install and `mint bootstrap` in the shared CI composite action.
> 
> Refreshes developer tooling and build configs: bumps `SwiftLint`/`Sourcery` versions, regenerates mocks with Sourcery 2.3.0, loosens SwiftLint `type_body_length`, and raises ContractTests’ Swift tools/platform minimums. In the SDK, refactors `identify` hook plumbing (`_identifyHooked`/`_identify` renamed to `identifyHooked`/`identifyImpl`) and makes minor style/visibility cleanups; adds/renames test specs in the Xcode project and removes the custom `LDChangedFlag` initializer (leaving it as a public memberwise init).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e28647fea05fdbef0d936cdd0a7a525419e948a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->