### PR TITLE
chore: Fix incorrect macos version for release process

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -3,13 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Is this a dry run. If so no package will be published.'
+        description: "Is this a dry run. If so no package will be published."
         type: boolean
         required: true
 
 jobs:
   build-publish:
-    runs-on: macos-14
+    runs-on: macos-15
 
     # Needed to get tokens during publishing.
     permissions:
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
-        name: 'Get Cocoapods token'
+        name: "Get Cocoapods token"
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/cocoapods/token = COCOAPODS_TRUNK_TOKEN'
+          ssm_parameter_pairs: "/production/common/releasing/cocoapods/token = COCOAPODS_TRUNK_TOKEN"
 
       - uses: ./.github/actions/ci
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-package:
-    runs-on: macos-14
+    runs-on: macos-15
 
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions workflow runner images (and minor YAML quoting), with no production code or release logic changes.
> 
> **Overview**
> Updates the release and manual publish GitHub Actions workflows to run on `macos-15` instead of `macos-14`.
> 
> Also normalizes a few YAML strings to double quotes in `manual-publish.yml` (e.g., input description, step name, and `ssm_parameter_pairs`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29de18d00fa207ebbf95401ddb8370d9e2474b82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->