### PR TITLE
chore: Tweak flaky test

### DIFF
--- a/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
@@ -40,7 +40,7 @@ final class DarklyServiceSpec: QuickSpec {
 
         func runStubbedGet(statusCode: Int, featureFlags: [LDFlagKey: FeatureFlag]? = nil, flagResponseEtag: String? = nil) {
             serviceMock.stubFlagRequest(statusCode: statusCode, useReport: config.useReport, flagResponseEtag: flagResponseEtag)
-            waitUntil { done in
+            waitUntil(timeout: .seconds(5)) { done in
                 self.service.getFeatureFlags(useReport: Constants.useGetMethod, completion: { _ in
                     done()
                 })
@@ -83,7 +83,7 @@ final class DarklyServiceSpec: QuickSpec {
                 context("success") {
                     context("without flag request etag") {
                         beforeEach {
-                            waitUntil { done in
+                            waitUntil(timeout: .seconds(5)) { done in
                                 testContext.serviceMock.stubFlagRequest(statusCode: HTTPURLResponse.StatusCodes.ok,
                                                                         featureFlags: testContext.stubFlags.featureFlags,
                                                                         useReport: Constants.useReportMethod,
@@ -136,7 +136,7 @@ final class DarklyServiceSpec: QuickSpec {
                         beforeEach {
                             testContext = TestContext(mobileKey: LDConfig.Constants.mockMobileKey, useReport: Constants.useGetMethod)
                             testContext.service.flagRequestEtag = requestEtag
-                            waitUntil { done in
+                            waitUntil(timeout: .seconds(5)) { done in
                                 testContext.serviceMock.stubFlagRequest(statusCode: HTTPURLResponse.StatusCodes.ok,
                                                                         featureFlags: testContext.stubFlags.featureFlags,
                                                                         useReport: Constants.useReportMethod,
@@ -190,7 +190,7 @@ final class DarklyServiceSpec: QuickSpec {
                 }
                 context("failure") {
                     beforeEach {
-                        waitUntil { done in
+                        waitUntil(timeout: .seconds(5)) { done in
                             testContext.serviceMock.stubFlagRequest(statusCode: HTTPURLResponse.StatusCodes.internalServerError,
                                                                     useReport: Constants.useReportMethod,
                                                                     onActivation: { _ in
@@ -250,7 +250,7 @@ final class DarklyServiceSpec: QuickSpec {
                 context("success") {
                     context("without a flag request etag") {
                         beforeEach {
-                            waitUntil { done in
+                            waitUntil(timeout: .seconds(5)) { done in
                                 testContext.serviceMock.stubFlagRequest(statusCode: HTTPURLResponse.StatusCodes.ok,
                                                                         featureFlags: testContext.stubFlags.featureFlags,
                                                                         useReport: Constants.useGetMethod,
@@ -302,7 +302,7 @@ final class DarklyServiceSpec: QuickSpec {
                         beforeEach {
                             testContext = TestContext(mobileKey: LDConfig.Constants.mockMobileKey, useReport: Constants.useReportMethod)
                             testContext.service.flagRequestEtag = requestEtag
-                            waitUntil { done in
+                            waitUntil(timeout: .seconds(5)) { done in
                                 testContext.serviceMock.stubFlagRequest(statusCode: HTTPURLResponse.StatusCodes.ok,
                                                                         featureFlags: testContext.stubFlags.featureFlags,
                                                                         useReport: Constants.useGetMethod,
@@ -354,7 +354,7 @@ final class DarklyServiceSpec: QuickSpec {
                 }
                 context("failure") {
                     beforeEach {
-                        waitUntil { done in
+                        waitUntil(timeout: .seconds(5)) { done in
                             testContext.serviceMock.stubFlagRequest(statusCode: HTTPURLResponse.StatusCodes.internalServerError,
                                                                     useReport: Constants.useReportMethod,
                                                                     onActivation: { _ in
@@ -582,7 +582,7 @@ final class DarklyServiceSpec: QuickSpec {
             context("success") {
                 var responses: ServiceResponses!
                 beforeEach {
-                    waitUntil { done in
+                    waitUntil(timeout: .seconds(5)) { done in
                         testContext.serviceMock.stubEventRequest(success: true) { eventRequest = $0 }
                         testContext.service.publishEventData(testData, UUID().uuidString) { response in
                             responses = (response.data, response.urlResponse, response.error)
@@ -604,7 +604,7 @@ final class DarklyServiceSpec: QuickSpec {
             context("failure") {
                 var responses: ServiceResponses!
                 beforeEach {
-                    waitUntil { done in
+                    waitUntil(timeout: .seconds(5)) { done in
                         testContext.serviceMock.stubEventRequest(success: false) { eventRequest = $0 }
                         testContext.service.publishEventData(testData, UUID().uuidString) { response in
                             responses = (response.data, response.urlResponse, response.error)
@@ -681,7 +681,7 @@ final class DarklyServiceSpec: QuickSpec {
             context("success") {
                 var responses: ServiceResponses!
                 beforeEach {
-                    waitUntil { done in
+                    waitUntil(timeout: .seconds(5)) { done in
                         testContext.serviceMock.stubDiagnosticRequest(success: true) { request, _, _ in
                             diagnosticRequest = request
                         }

--- a/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Networking/DarklyServiceSpec.swift
@@ -712,7 +712,7 @@ final class DarklyServiceSpec: QuickSpec {
             context("failure") {
                 var responses: ServiceResponses!
                 beforeEach {
-                    waitUntil { done in
+                    waitUntil(timeout: .seconds(5)) { done in
                         testContext.serviceMock.stubEventRequest(success: false) { diagnosticRequest = $0 }
                         testContext.service.publishDiagnostic(diagnosticEvent: self.stubDiagnostic()) { response in
                             responses = (response.data, response.urlResponse, response.error)

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/FeatureFlagCacheSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/FeatureFlagCacheSpec.swift
@@ -126,7 +126,8 @@ final class FeatureFlagCacheSpec: XCTestCase {
     func testStoreValidData() throws {
         mockValueCache.setCallback = {
             if let received = self.mockValueCache.setReceivedArguments, received.forKey.starts(with: "flags-") {
-                XCTAssertEqual(received.value, try JSONEncoder().encode(self.testFlagCollection))
+                let decoded = try JSONDecoder().decode(StoredItemCollection.self, from: received.value)
+                XCTAssertEqual(decoded.flags, self.testFlagCollection.flags)
             }
         }
         let flagCache = FeatureFlagCache(serviceFactory: serviceFactory, mobileKey: "abc", maxCachedContexts: 1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes that add explicit async timeouts and make cache assertions resilient to encoding differences; no production code paths are modified.
> 
> **Overview**
> Improves reliability of `DarklyServiceSpec` by adding an explicit `waitUntil(timeout: .seconds(5))` to multiple async expectations to reduce flakiness.
> 
> Updates `FeatureFlagCacheSpec.testStoreValidData` to validate persisted flags by decoding the stored payload (`StoredItemCollection`) and comparing the decoded `flags`, rather than asserting byte-for-byte equality of JSON-encoded data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ff9c4987475ddfde7edffd32da11c3ab8cf39ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->