### PR TITLE
chore: Ensure done() is called only once in LDTimerSpec

### DIFF
--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/LDTimerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/LDTimerSpec.swift
@@ -42,6 +42,7 @@ final class LDTimerSpec: QuickSpec {
         describe("timerFired") {
             it("calls execute on the fireQueue multiple times") {
                 var fireCount = 0
+                var didCallDone = false
                 var testContext: TestContext!
                 waitUntil { done in
                     // timeInterval is arbitrary here. "Fast" so the test doesn't take a long time.
@@ -49,7 +50,8 @@ final class LDTimerSpec: QuickSpec {
                         dispatchPrecondition(condition: .onQueue(testContext.fireQueue))
                         if fireCount < 2 {
                             fireCount += 1  // If the timer fires again before the test is done, that's ok. This just measures an arbitrary point in time.
-                        } else {
+                        } else if !didCallDone {
+                            didCallDone = true
                             done()
                         }
                     })


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: Ensure done() is called only once in LDTimerSpec
END_COMMIT_OVERRIDE

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v11/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Fixes the `build-ios (15.4.0, platform=iOS Simulator,name=iPhone 15, macos-14)` CI failure:
```
timerFired__calls_execute_on_the_fireQueue_multiple_times, failed - waitUntil(..) expects its completion closure to be only called once
```

**Describe the solution you've provided**

The `timerFiredSpec` test creates a repeating timer with a 0.01s interval inside a `waitUntil` block. After `fireCount` reaches 2, the `else` branch calls `done()`. Because the timer continues to fire every 10ms, `done()` was being called on every subsequent fire before Nimble could tear down the `waitUntil`, violating the exactly-once contract.

This PR adds a `didCallDone` guard so that `done()` is invoked only on the first eligible timer fire and skipped thereafter.

**Describe alternatives you've considered**

Cancelling the timer inside the callback before calling `done()` would also work, but that would change what the test is asserting (the test expects the timer to still be valid and not cancelled after `waitUntil` completes — see lines 58–60).

**Additional context**

**For reviewer** — the callback executes on `testContext.fireQueue`, which is a serial `DispatchQueue`, so concurrent access to `didCallDone` is not a concern. No production code is changed.

Link to Devin session: https://app.devin.ai/sessions/f07904a28c9048778d5b15d1d2c8eba5
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that prevents `waitUntil`'s `done()` callback from being invoked multiple times by a fast repeating timer.
> 
> **Overview**
> Stabilizes the `LDTimerSpec.timerFired` test by guarding the `waitUntil` completion so `done()` is only invoked once even if the repeating timer continues to fire.
> 
> This fixes a flaky/CI-failing condition where the test could call `done()` multiple times without changing any production behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498ad90aa37890f22f5918483f1aadf8f96c1daf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->