### PR TITLE
fix: Call identify hooks during init.

### DIFF
--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -970,10 +970,8 @@ public class LDClient {
 
         var hookState: IdentifyHookState? = nil
         if !hooks.isEmpty {
-            let seriesContext = IdentifySeriesContext(context: context, methodName: "identify")
-            let seriesData = hooks.map { hook in
-                hook.beforeIdentify(seriesContext: seriesContext, seriesData: EvaluationSeriesData())
-            }
+            let seriesContext = IdentifySeriesContext(context: context, methodName: "init")
+            let seriesData = hooks.map { hook in hook.beforeIdentify(seriesContext: seriesContext, seriesData: EvaluationSeriesData()) }
             hookState = IdentifyHookState(seriesContext: seriesContext, seriesData: seriesData, hooksSnapshot: hooks)
         }
 

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -995,12 +995,16 @@ public class LDClient {
             flagStore.replaceStore(newStoredItems: cachedFlags)
         }
 
+        let hookState = executeBeforeIdentifyHooks(context: context)
         eventReporter.record(IdentifyEvent(context: context))
         self.connectionInformation = ConnectionInformation.uncacheConnectionInformation(config: config, ldClient: self, clientServiceFactory: self.serviceFactory)
 
         internalSetOnline(configuration.startOnline) {
             os_log("%s LDClient started", log: configuration.logger, type: .debug, self.typeName(and: #function))
             completion?()
+            if let state = hookState {
+                self.executeAfterIdentifyHooks(state: state, result: .complete)
+            }
         }
     }
 }

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -836,17 +836,6 @@ public class LDClient {
                 credential: mobileKey
             )
 
-            // add all the plugin hooks
-            for plugin in config.plugins {
-                // Catch to protect against any runtime exceptions from plugin
-                do {
-                    let pluginHooks = try plugin.getHooks(metadata: environmentMetadata)
-                    instance.hooks.append(contentsOf: pluginHooks)
-                } catch {
-                    os_log("Exception thrown getting hooks for plugin %@. Unable to get hooks, plugin will not be registered.", log: config.logger, type: .error, plugin.getMetadata().getName())
-                }
-            }
-
             // now register the client with all the plugins
             for plugin in config.plugins {
                 do {
@@ -949,6 +938,24 @@ public class LDClient {
         self.serviceFactory = serviceFactory
         self.hooks = Array(configuration.hooks)
         environmentReporter = self.serviceFactory.makeEnvironmentReporter(config: configuration)
+
+        // Collect plugin hooks before executeBeforeIdentifyHooks so plugin hooks
+        // participate in the init identify lifecycle.
+        let initSdkMetadata = SdkMetadata(name: SystemCapabilities.systemName, version: ReportingConsts.sdkVersion)
+        let initEnvironmentMetadata = EnvironmentMetadata(
+            applicationInfo: environmentReporter.applicationInfo,
+            sdkMetadata: initSdkMetadata,
+            credential: configuration.mobileKey
+        )
+        for plugin in configuration.plugins {
+            do {
+                let pluginHooks = try plugin.getHooks(metadata: initEnvironmentMetadata)
+                self.hooks.append(contentsOf: pluginHooks)
+            } catch {
+                os_log("Exception thrown getting hooks for plugin %@. Unable to get hooks, plugin will not be registered.", log: configuration.logger, type: .error, plugin.getMetadata().getName())
+            }
+        }
+
         flagCache = self.serviceFactory.makeFeatureFlagCache(mobileKey: configuration.mobileKey, maxCachedContexts: configuration.maxCachedContexts)
         flagStore = self.serviceFactory.makeFlagStore()
         flagChangeNotifier = self.serviceFactory.makeFlagChangeNotifier()

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -939,8 +939,7 @@ public class LDClient {
         self.hooks = Array(configuration.hooks)
         environmentReporter = self.serviceFactory.makeEnvironmentReporter(config: configuration)
 
-        // Collect plugin hooks before executeBeforeIdentifyHooks so plugin hooks
-        // participate in the init identify lifecycle.
+        // Collect plugin hooks before calling beforeIdentify, so plugin hooks participate in the init identify lifecycle.
         let initSdkMetadata = SdkMetadata(name: SystemCapabilities.systemName, version: ReportingConsts.sdkVersion)
         let initEnvironmentMetadata = EnvironmentMetadata(
             applicationInfo: environmentReporter.applicationInfo,
@@ -969,10 +968,20 @@ public class LDClient {
             context = AutoEnvContextModifier(environmentReporter: environmentReporter, logger: config.logger).modifyContext(context)
         }
 
+        var hookState: IdentifyHookState? = nil
+        if !hooks.isEmpty {
+            let seriesContext = IdentifySeriesContext(context: context, methodName: "identify")
+            let seriesData = hooks.map { hook in
+                hook.beforeIdentify(seriesContext: seriesContext, seriesData: EvaluationSeriesData())
+            }
+            hookState = IdentifyHookState(seriesContext: seriesContext, seriesData: seriesData, hooksSnapshot: hooks)
+        }
+
         service = self.serviceFactory.makeDarklyServiceProvider(config: config, context: context, envReporter: environmentReporter)
         diagnosticReporter = self.serviceFactory.makeDiagnosticReporter(config: config, service: service, environmentReporter: environmentReporter)
         eventReporter = self.serviceFactory.makeEventReporter(config: config, service: service)
         connectionInformation = self.serviceFactory.makeConnectionInformation()
+
         let cachedData = flagCache.getCachedData(cacheKey: context.fullyQualifiedHashedKey(), contextHash: context.contextHash())
         flagSynchronizer = self.serviceFactory.makeFlagSynchronizer(streamingMode: config.allowStreamingMode ? config.streamingMode : .polling,
                                                                     pollingInterval: config.flagPollingInterval(runMode: runMode),
@@ -1002,7 +1011,6 @@ public class LDClient {
             flagStore.replaceStore(newStoredItems: cachedFlags)
         }
 
-        let hookState = executeBeforeIdentifyHooks(context: context)
         eventReporter.record(IdentifyEvent(context: context))
         self.connectionInformation = ConnectionInformation.uncacheConnectionInformation(config: config, ldClient: self, clientServiceFactory: self.serviceFactory)
 

--- a/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClientIdentifyHook.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension LDClient {
-    private struct IdentifyHookState {
+    internal struct IdentifyHookState {
         let seriesContext: IdentifySeriesContext
         let seriesData: [IdentifySeriesData]
         let hooksSnapshot: [Hook]
@@ -17,7 +17,7 @@ extension LDClient {
         }
     }
 
-    private func executeBeforeIdentifyHooks(context: LDContext) -> IdentifyHookState? {
+    internal func executeBeforeIdentifyHooks(context: LDContext) -> IdentifyHookState? {
         guard !hooks.isEmpty else {
             return nil
         }
@@ -30,7 +30,7 @@ extension LDClient {
         return IdentifyHookState(seriesContext: seriesContext, seriesData: seriesData, hooksSnapshot: hooksSnapshot)
     }
 
-    private func executeAfterIdentifyHooks(state: IdentifyHookState, result: IdentifyResult) {
+    internal func executeAfterIdentifyHooks(state: IdentifyHookState, result: IdentifyResult) {
         guard !state.hooksSnapshot.isEmpty else {
             return
         }

--- a/LaunchDarkly/LaunchDarklyTests/LDClientIdentifyHookSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientIdentifyHookSpec.swift
@@ -96,8 +96,41 @@ final class LDClientIdentifyHookSpec: XCTestCase {
         expect(seriesData?["before"] as? String).toEventually(equal("was called"))
     }
 
+    func testPluginHooksFireDuringInit() {
+        var count = 0
+        let hook = MockHook(before: { _, data in count += 1; return data }, after: { _, data, _ in count += 2; return data })
+        let plugin = MockPlugin(hooks: [hook])
+        var config = LDConfig(mobileKey: "mobile-key", autoEnvAttributes: .disabled)
+        config.plugins = [plugin]
+        var testContext: TestContext!
+        waitUntil { done in
+            testContext = TestContext(newConfig: config)
+            testContext.start(completion: done)
+        }
+        // before=1, after=2 from init identify; no explicit identify call
+        expect(count).toEventually(equal(3))
+    }
+
     typealias BeforeHook = (_: IdentifySeriesContext, _: IdentifySeriesData) -> IdentifySeriesData
     typealias AfterHook = (_: IdentifySeriesContext, _: IdentifySeriesData, _: IdentifyResult) -> IdentifySeriesData
+
+    class MockPlugin: Plugin {
+        let hooks: [Hook]
+
+        init(hooks: [Hook]) {
+            self.hooks = hooks
+        }
+
+        func getMetadata() -> LaunchDarkly.PluginMetadata {
+            return PluginMetadata(name: "mock-plugin")
+        }
+
+        func register(client: LaunchDarkly.LDClient, metadata: LaunchDarkly.EnvironmentMetadata) {}
+
+        func getHooks(metadata: LaunchDarkly.EnvironmentMetadata) -> [LaunchDarkly.Hook] {
+            return hooks
+        }
+    }
 
     class MockHook: Hook {
         let before: BeforeHook

--- a/LaunchDarkly/LaunchDarklyTests/LDClientIdentifyHookSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientIdentifyHookSpec.swift
@@ -18,7 +18,7 @@ final class LDClientIdentifyHookSpec: XCTestCase {
             testContext.start(completion: done)
         }
         testContext.subject.identify(context: LDContext.stub()) { _ in }
-        expect(count).toEventually(equal(3))
+        expect(count).toEventually(equal(6))
     }
 
     func testRegistrationWithTimeout() {
@@ -32,13 +32,13 @@ final class LDClientIdentifyHookSpec: XCTestCase {
             testContext.start(completion: done)
         }
         testContext.subject.identify(context: LDContext.stub(), timeout: 30.0) { _ in }
-        expect(count).toEventually(equal(3))
+        expect(count).toEventually(equal(6))
     }
 
     func testIdentifyOrder() {
         var callRecord: [String] = []
-        let firstHook = MockHook(before: { _, data in callRecord.append("first before"); return data }, after: { _, data, _ in callRecord.append("first after"); return data })
-        let secondHook = MockHook(before: { _, data in callRecord.append("second before"); return data }, after: { _, data, _ in callRecord.append("second after"); return data })
+        let firstHook = MockHook(before: { sc, data in callRecord.append("first before \(sc.context.fullyQualifiedKey())"); return data }, after: { sc, data, _ in callRecord.append("first after \(sc.context.fullyQualifiedKey())"); return data })
+        let secondHook = MockHook(before: { sc, data in callRecord.append("second before \(sc.context.fullyQualifiedKey())"); return data }, after: { sc, data, _ in callRecord.append("second after \(sc.context.fullyQualifiedKey())"); return data })
         var config = LDConfig(mobileKey: "mobile-key", autoEnvAttributes: .disabled)
         config.hooks = [firstHook, secondHook]
 
@@ -48,8 +48,12 @@ final class LDClientIdentifyHookSpec: XCTestCase {
             testContext.start(completion: done)
         }
 
-        testContext.subject.identify(context: LDContext.stub()) { _ in }
-        expect(callRecord).toEventually(equal(["first before", "second before", "second after", "first after"]))
+        let initKey = testContext.subject.context.fullyQualifiedKey()
+        testContext.subject.identify(context: LDContext.stub(key: "explicit-context")) { _ in }
+        expect(callRecord).toEventually(equal([
+            "first before \(initKey)", "second before \(initKey)", "second after \(initKey)", "first after \(initKey)",
+            "first before explicit-context", "second before explicit-context", "second after explicit-context", "first after explicit-context"
+        ]))
     }
 
     func testIdentifyResultIsCaptured() {


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/v11/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Before this change, `beforeIdentify` and `afterIdentify` were only called when `identify` was called. After this change, they are also called as part of `init`.

**Describe alternatives you've considered**

None.

**Additional context**

I don't think this would be considered a breaking change, but I wouldn't mind a second opinion. The change in behavior is observable by the user, but the new behavior is what was originally intended. So I would consider this a bugfix, and would not expect customers to need to make any changes to their code to deal with the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observable hook execution timing by invoking `beforeIdentify`/`afterIdentify` during `LDClient` init and by including plugin-provided hooks in that lifecycle, which could affect apps with side-effecting hooks. Scope is limited to hook plumbing and tests, with no auth or data model changes.
> 
> **Overview**
> `LDClient` now executes identify hooks as part of initialization: it runs `beforeIdentify` with method name `"init"` and defers `afterIdentify` until the initial `setOnline` completes.
> 
> Plugin hooks are collected earlier (during `LDClient` init rather than `LDClient.start`) so plugin-provided hooks participate in the init identify lifecycle, and the hook helper APIs in `LDClientIdentifyHook.swift` are widened to `internal` to support this.
> 
> Tests are updated/expanded to assert the additional init-time hook calls, preserve hook ordering, and verify plugin hooks fire during init.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab0372abbf967254937777120a8234bd20548ab3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->