### PR TITLE
fix: app hang in didEnterBackground by making ConnectionInformationStore writes async

### DIFF
--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/ConnectionInformationStore.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/ConnectionInformationStore.swift
@@ -5,14 +5,12 @@ final class ConnectionInformationStore {
     private static let storeQueue = DispatchQueue(label: "com.launchDarkly.ConnectionInformationStore.storeQueue")
 
     static func retrieveStoredConnectionInformation() -> ConnectionInformation? {
-        storeQueue.sync {
-            UserDefaults.standard.retrieve(object: ConnectionInformation.self, fromKey: ConnectionInformationStore.connectionInformationKey)
-        }
+        UserDefaults.standard.retrieve(object: ConnectionInformation.self, fromKey: connectionInformationKey)
     }
 
     static func storeConnectionInformation(connectionInformation: ConnectionInformation) {
         storeQueue.async {
-            UserDefaults.standard.save(customObject: connectionInformation, forKey: ConnectionInformationStore.connectionInformationKey)
+            UserDefaults.standard.save(customObject: connectionInformation, forKey: connectionInformationKey)
         }
     }
 }

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/ConnectionInformationStore.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/ConnectionInformationStore.swift
@@ -2,13 +2,18 @@ import Foundation
 
 final class ConnectionInformationStore {
     private static let connectionInformationKey = "com.launchDarkly.ConnectionInformationStore.connectionInformationKey"
+    private static let storeQueue = DispatchQueue(label: "com.launchDarkly.ConnectionInformationStore.storeQueue")
 
     static func retrieveStoredConnectionInformation() -> ConnectionInformation? {
-        UserDefaults.standard.retrieve(object: ConnectionInformation.self, fromKey: ConnectionInformationStore.connectionInformationKey)
+        storeQueue.sync {
+            UserDefaults.standard.retrieve(object: ConnectionInformation.self, fromKey: ConnectionInformationStore.connectionInformationKey)
+        }
     }
 
     static func storeConnectionInformation(connectionInformation: ConnectionInformation) {
-        UserDefaults.standard.save(customObject: connectionInformation, forKey: ConnectionInformationStore.connectionInformationKey)
+        storeQueue.async {
+            UserDefaults.standard.save(customObject: connectionInformation, forKey: ConnectionInformationStore.connectionInformationKey)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Move `ConnectionInformationStore.storeConnectionInformation` from a synchronous `UserDefaults.set` call to an **async dispatch** on a dedicated serial queue, preventing the main thread from blocking during background transitions
- Reads go directly to `UserDefaults` without queue serialization — `UserDefaults` reads are thread-safe and this avoids blocking the main thread if a slow write is in-flight

Fixes #488

## Problem

When the app transitions to background, `LDClient.didEnterBackground` synchronously writes connection information to `NSUserDefaults` on the main thread:

```
LDClient.didEnterBackground → Thread.performOnMain (DispatchQueue.main.sync)
  → runMode.didSet → connectionInformation.didSet
    → ConnectionInformationStore.storeConnectionInformation
      → UserDefaults.set → -[NSOperation waitUntilFinished] → BLOCKED (5000+ ms)
```

`NSUserDefaults.set` can trigger cross-process synchronization that blocks the main thread, especially on MDM-managed devices with concurrent `NSUserDefaults` access. This causes a watchdog hang of 5000+ ms.

In our production app this has caused **7,016 hang events across 653 users**.

## Change

**File:** `LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/ConnectionInformationStore.swift`

```diff
 final class ConnectionInformationStore {
     private static let connectionInformationKey = "..."
+    private static let storeQueue = DispatchQueue(label: "com.launchDarkly.ConnectionInformationStore.storeQueue")

     static func retrieveStoredConnectionInformation() -> ConnectionInformation? {
-        UserDefaults.standard.retrieve(...)
+        UserDefaults.standard.retrieve(...)  // no queue — UserDefaults reads are thread-safe
     }

     static func storeConnectionInformation(connectionInformation: ConnectionInformation) {
-        UserDefaults.standard.save(...)
+        storeQueue.async {
+            UserDefaults.standard.save(...)
+        }
     }
 }
```

## Design decisions

- **Writes are async**: The `UserDefaults.set` call that causes the 5s+ hang is dispatched to a background serial queue, unblocking the main thread
- **Reads bypass the queue**: `UserDefaults` reads are inherently thread-safe (Apple documentation). `retrieveStoredConnectionInformation` is only called once during `LDClient.init`, when no writes are in-flight. Wrapping reads in `storeQueue.sync` would reintroduce the main-thread blocking if a slow write were queued
- **Connection information is advisory state** (diagnostic/logging) — eventual consistency is acceptable

## Test plan

- All 596 existing tests pass with 0 failures
- Verified `swift build` compiles cleanly
- Verified `swift test` passes all test suites

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence semantics by making `ConnectionInformationStore` writes asynchronous, which could introduce timing/race issues (e.g., last-write not yet flushed) though scope is limited to cached connection diagnostics.
> 
> **Overview**
> Prevents main-thread stalls when persisting connection diagnostics by dispatching `ConnectionInformationStore.storeConnectionInformation` UserDefaults writes onto a dedicated serial `DispatchQueue`.
> 
> Keeps `retrieveStoredConnectionInformation` reading directly from `UserDefaults` (no queue serialization) and simplifies key access to use the local `connectionInformationKey` constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2e2abf75d82b080ac71ae6cadb89d7e6f58a3ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->