### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         id: release
         with:
           target-branch: ${{ github.ref_name }}
@@ -43,7 +43,7 @@ jobs:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: "/production/common/releasing/cocoapods/token = COCOAPODS_TRUNK_TOKEN"
 
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # 60606e260d2fc5762a71e64e74b2174e8ea3c8bd
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           xcode-version: 16.4.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,7 +43,7 @@ jobs:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: "/production/common/releasing/cocoapods/token = COCOAPODS_TRUNK_TOKEN"
 
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # 60606e260d2fc5762a71e64e74b2174e8ea3c8bd
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           xcode-version: 16.4.0


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only update GitHub Actions references to fixed commit SHAs; behavior should remain the same aside from potential breakage if the pinned SHAs are incompatible.
> 
> **Overview**
> Pins third-party GitHub Actions used by the release workflow to specific commit SHAs (notably `googleapis/release-please-action` and `maxim-lobanov/setup-xcode`) to reduce supply-chain risk.
> 
> No functional release logic changes beyond updating how those actions are versioned/referenced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 730c9505ded13c24325bcc8ada7f8e9e451ab7e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->