### PR TITLE
fix: updates diagnostic cache to be memory only to remove concurrency bug

### DIFF
--- a/LaunchDarkly/GeneratedCode/mocks.generated.swift
+++ b/LaunchDarkly/GeneratedCode/mocks.generated.swift
@@ -41,15 +41,6 @@ final class DarklyStreamingProviderMock: DarklyStreamingProvider {
 // MARK: - DiagnosticCachingMock
 final class DiagnosticCachingMock: DiagnosticCaching {
 
-    var lastStatsSetCount = 0
-    var setLastStatsCallback: (() throws -> Void)?
-    var lastStats: DiagnosticStats? = nil {
-        didSet {
-            lastStatsSetCount += 1
-            try! setLastStatsCallback?()
-        }
-    }
-
     var getDiagnosticIdCallCount = 0
     var getDiagnosticIdCallback: (() throws -> Void)?
     var getDiagnosticIdReturnValue: DiagnosticId!

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/DiagnosticCache.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/Cache/DiagnosticCache.swift
@@ -2,8 +2,6 @@ import Foundation
 
 // sourcery: autoMockable
 protocol DiagnosticCaching {
-    var lastStats: DiagnosticStats? { get }
-
     func getDiagnosticId() -> DiagnosticId
     func getCurrentStatsAndReset() -> DiagnosticStats
     func incrementDroppedEventCount()
@@ -11,116 +9,71 @@ protocol DiagnosticCaching {
     func addStreamInit(streamInit: DiagnosticStreamInit)
 }
 
+/// In-memory diagnostic statistics (no persistence).
+///
+/// Older releases stored JSON in `UserDefaults` using the following key forms and
+/// these key forms should not be reused to avoid collision with existing data:
+/// `com.launchdarkly.DiagnosticCache.diagnosticData`, forming keys of the form
+/// `com.launchdarkly.DiagnosticCache.diagnosticData.<mobileKey>`.
 final class DiagnosticCache: DiagnosticCaching {
-    private static let diagnosticDataKey = "com.launchdarkly.DiagnosticCache.diagnosticData"
     private static let cacheQueueLabel = "com.launchdarkly.DiagnosticCache.cacheQueue"
 
     private let sdkKey: String
-    private let dataKey: String
-
-    private(set) var lastStats: DiagnosticStats?
-
     private var cacheQueue = DispatchQueue(label: cacheQueueLabel)
+
+    private var instanceId: String
+    private var dataSinceDate: Int64
+    private var droppedEvents: Int
+    private var eventsInLastBatch: Int
+    private var streamInits: [DiagnosticStreamInit]
 
     init(sdkKey: String) {
         self.sdkKey = sdkKey
-        self.dataKey = "\(DiagnosticCache.diagnosticDataKey).\(sdkKey)"
-
-        if let storedData = StoreData.load(from: dataKey) {
-            let oldId = DiagnosticId(diagnosticId: storedData.instanceId, sdkKey: sdkKey)
-            lastStats = DiagnosticStats(id: oldId, creationDate: Date().millisSince1970, dataSinceDate: storedData.dataSinceDate, droppedEvents: storedData.droppedEvents, eventsInLastBatch: storedData.eventsInLastBatch, streamInits: storedData.streamInits)
-        }
-        StoreData.defaultWithRandomId().save(dataKey)
+        self.instanceId = UUID().uuidString
+        self.dataSinceDate = Date().millisSince1970
+        self.droppedEvents = 0
+        self.eventsInLastBatch = 0
+        self.streamInits = []
     }
 
     func getDiagnosticId() -> DiagnosticId {
-        let stored = cacheQueue.sync { loadOrSetup() }
-        return DiagnosticId(diagnosticId: stored.instanceId, sdkKey: sdkKey)
+        cacheQueue.sync {
+            DiagnosticId(diagnosticId: instanceId, sdkKey: sdkKey)
+        }
     }
 
     func getCurrentStatsAndReset() -> DiagnosticStats {
-        let now = Date().millisSince1970
-        // swiftlint:disable:next implicitly_unwrapped_optional
-        var stored: StoreData!
         cacheQueue.sync {
-            stored = loadOrSetup()
-            updateStoredData {
-                $0.dataSinceDate = now
-                $0.droppedEvents = 0
-                $0.eventsInLastBatch = 0
-                $0.streamInits = []
-            }
+            let now = Date().millisSince1970
+            let stats = DiagnosticStats(id: DiagnosticId(diagnosticId: instanceId, sdkKey: sdkKey),
+                                        creationDate: now,
+                                        dataSinceDate: dataSinceDate,
+                                        droppedEvents: droppedEvents,
+                                        eventsInLastBatch: eventsInLastBatch,
+                                        streamInits: streamInits)
+            dataSinceDate = now
+            droppedEvents = 0
+            eventsInLastBatch = 0
+            streamInits = []
+            return stats
         }
-        return DiagnosticStats(id: DiagnosticId(diagnosticId: stored.instanceId, sdkKey: sdkKey),
-                               creationDate: now,
-                               dataSinceDate: stored.dataSinceDate,
-                               droppedEvents: stored.droppedEvents,
-                               eventsInLastBatch: stored.eventsInLastBatch,
-                               streamInits: stored.streamInits)
     }
 
     func incrementDroppedEventCount() {
-        updateStoredDataSync { $0.droppedEvents += 1 }
+        cacheQueue.sync {
+            droppedEvents += 1
+        }
     }
 
     func recordEventsInLastBatch(eventsInLastBatch: Int) {
-        updateStoredDataSync { $0.eventsInLastBatch = eventsInLastBatch }
+        cacheQueue.sync {
+            self.eventsInLastBatch = eventsInLastBatch
+        }
     }
 
     func addStreamInit(streamInit: DiagnosticStreamInit) {
-        updateStoredDataSync { $0.streamInits.append(streamInit) }
-    }
-
-    private func loadOrSetup() -> StoreData {
-        let stored = StoreData.load(from: dataKey)
-        if let storeData = stored {
-            return storeData
-        } else {
-            let new = StoreData.defaultWithRandomId()
-            new.save(dataKey)
-            return new
+        cacheQueue.sync {
+            streamInits.append(streamInit)
         }
-    }
-
-    private func updateStoredDataSync(updateFunc: (inout StoreData) -> Void) {
-        cacheQueue.sync { updateStoredData(updateFunc: updateFunc) }
-    }
-
-    private func updateStoredData(updateFunc: (inout StoreData) -> Void) {
-        var storeData = StoreData.load(from: dataKey) ?? StoreData.defaultWithRandomId()
-        updateFunc(&storeData)
-        storeData.save(dataKey)
-    }
-}
-
-private struct StoreData: Codable {
-    let instanceId: String
-    var dataSinceDate: Int64
-    var droppedEvents: Int
-    var eventsInLastBatch: Int
-    var streamInits: [DiagnosticStreamInit]
-
-    static func defaultWithRandomId() -> StoreData {
-        StoreData(instanceId: UUID().uuidString, dataSinceDate: Date().millisSince1970, droppedEvents: 0, eventsInLastBatch: 0, streamInits: [])
-    }
-
-    static func load(from: String) -> StoreData? {
-        let defaults = UserDefaults.standard
-        if let storedData = defaults.data(forKey: from) {
-            do {
-                return try JSONDecoder().decode(self, from: storedData)
-            } catch {
-                defaults.removeObject(forKey: from)
-            }
-        }
-        return nil
-    }
-
-    func save(_ toKey: String) {
-        let defaults = UserDefaults.standard
-        do {
-            let encoded: Data = try JSONEncoder().encode(self)
-            defaults.set(encoded, forKey: toKey)
-        } catch {}
     }
 }

--- a/LaunchDarkly/LaunchDarkly/ServiceObjects/DiagnosticReporter.swift
+++ b/LaunchDarkly/LaunchDarkly/ServiceObjects/DiagnosticReporter.swift
@@ -39,9 +39,6 @@ class DiagnosticReporter: DiagnosticReporting {
             if let cache = self.service.diagnosticCache {
                 if !sentInit {
                     sentInit = true
-                    if let lastStats = cache.lastStats {
-                        sendDiagnosticEventAsync(diagnosticEvent: lastStats)
-                    }
                     let initEvent = DiagnosticInit(config: service.config,
                                                    environmentReporting: environmentReporting,
                                                    diagnosticId: cache.getDiagnosticId(),

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/DiagnosticCacheSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/Cache/DiagnosticCacheSpec.swift
@@ -10,23 +10,17 @@ final class DiagnosticCacheSpec: QuickSpec {
             incrementDroppedEventCountSpec()
             recordEventsInLastBatchSpec()
             addStreamInitSpec()
-            lastStatsSpec()
-            backingStoreSpec()
         }
     }
 
     private func getCurrentStatsAndResetSpec() {
         context("getCurrentStatsAndReset") {
-            beforeEach {
-                self.clearStoredCaches()
-            }
             it("has expected initial values") {
                 let diagnosticCache = DiagnosticCache(sdkKey: "this_is_a_fake_key")
                 let diagnosticId = diagnosticCache.getDiagnosticId()
                 Thread.sleep(forTimeInterval: 0.01)
                 let diagnosticStats = diagnosticCache.getCurrentStatsAndReset()
                 let now = Date().millisSince1970
-                expect(diagnosticCache.lastStats).to(beNil())
                 expect(diagnosticId.sdkKeySuffix) == "ke_key"
                 expect(UUID(uuidString: diagnosticId.diagnosticId)).toNot(beNil())
                 expect(diagnosticStats.id.sdkKeySuffix) == diagnosticId.sdkKeySuffix
@@ -63,9 +57,6 @@ final class DiagnosticCacheSpec: QuickSpec {
 
     private func incrementDroppedEventCountSpec() {
         context("incrementDroppedEventCount") {
-            beforeEach {
-                self.clearStoredCaches()
-            }
             it("increments dropped event count") {
                 let diagnosticCache = DiagnosticCache(sdkKey: "this_is_a_fake_key")
                 let diagnosticId = diagnosticCache.getDiagnosticId()
@@ -105,9 +96,6 @@ final class DiagnosticCacheSpec: QuickSpec {
 
     private func recordEventsInLastBatchSpec() {
         context("recordEventsInLastBatch") {
-            beforeEach {
-                self.clearStoredCaches()
-            }
             it("sets events in last batch") {
                 let diagnosticCache = DiagnosticCache(sdkKey: "this_is_a_fake_key")
                 let diagnosticId = diagnosticCache.getDiagnosticId()
@@ -130,9 +118,6 @@ final class DiagnosticCacheSpec: QuickSpec {
 
     private func addStreamInitSpec() {
         context("addStreamInit") {
-            beforeEach {
-                self.clearStoredCaches()
-            }
             it("adds a stream init") {
                 let diagnosticCache = DiagnosticCache(sdkKey: "this_is_a_fake_key")
                 let diagnosticId = diagnosticCache.getDiagnosticId()
@@ -193,72 +178,5 @@ final class DiagnosticCacheSpec: QuickSpec {
                 }
             }
         }
-    }
-
-    private func lastStatsSpec() {
-        context("lastStats") {
-            beforeEach {
-                self.clearStoredCaches()
-            }
-            it("restores from previous initialization with same key") {
-                let diagnosticCache = DiagnosticCache(sdkKey: "this_is_a_fake_key")
-                let diagnosticId = diagnosticCache.getDiagnosticId()
-                let initialStats = diagnosticCache.getCurrentStatsAndReset()
-                diagnosticCache.incrementDroppedEventCount()
-                diagnosticCache.recordEventsInLastBatch(eventsInLastBatch: 5)
-                diagnosticCache.addStreamInit(streamInit: DiagnosticStreamInit(timestamp: 100, durationMillis: 50, failed: false))
-                let restoredCache = DiagnosticCache(sdkKey: "this_is_a_fake_key")
-                let restoredId = restoredCache.getDiagnosticId()
-                guard let lastStats = restoredCache.lastStats
-                else {
-                    fail("No restored stats")
-                    return
-                }
-                expect(lastStats.id.diagnosticId) == diagnosticId.diagnosticId
-                expect(lastStats.id.sdkKeySuffix) == diagnosticId.sdkKeySuffix
-                expect(restoredId.diagnosticId) != diagnosticId.diagnosticId
-                expect(restoredId.sdkKeySuffix) == diagnosticId.sdkKeySuffix
-                expect(lastStats.creationDate) >= initialStats.creationDate
-                expect(lastStats.dataSinceDate) == initialStats.creationDate
-                expect(lastStats.droppedEvents) == 1
-                expect(lastStats.eventsInLastBatch) == 5
-                expect(lastStats.streamInits.count) == 1
-                expect(lastStats.streamInits[0].timestamp) == 100
-                expect(lastStats.streamInits[0].durationMillis) == 50
-                expect(lastStats.streamInits[0].failed) == false
-            }
-            it("does not restore from previous initialization with different key") {
-                let diagnosticCache = DiagnosticCache(sdkKey: "this_is_a_fake_key")
-                diagnosticCache.incrementDroppedEventCount()
-                diagnosticCache.recordEventsInLastBatch(eventsInLastBatch: 5)
-                diagnosticCache.addStreamInit(streamInit: DiagnosticStreamInit(timestamp: 100, durationMillis: 50, failed: false))
-                let restoredCache = DiagnosticCache(sdkKey: "this_is_a_different_fake_key")
-                let lastStats = restoredCache.lastStats
-                expect(lastStats).to(beNil())
-            }
-        }
-    }
-
-    private func backingStoreSpec() {
-        context("backing store") {
-            it("stores to expected key") {
-                self.clearStoredCaches()
-
-                let expectedDataKey = "com.launchdarkly.DiagnosticCache.diagnosticData.this_is_a_fake_key"
-                let defaults = UserDefaults.standard
-                let beforeData = defaults.data(forKey: expectedDataKey)
-                expect(beforeData).to(beNil())
-                _ = DiagnosticCache(sdkKey: "this_is_a_fake_key")
-                let afterData = defaults.data(forKey: expectedDataKey)
-                expect(afterData).toNot(beNil())
-            }
-        }
-    }
-
-    private func clearStoredCaches() {
-        let defaults = UserDefaults.standard
-        defaults.dictionaryRepresentation().keys.filter {
-            $0.starts(with: "com.launchdarkly.DiagnosticCache.diagnosticData")
-        }.forEach { defaults.removeObject(forKey: $0) }
     }
 }

--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/DiagnosticReporterSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/DiagnosticReporterSpec.swift
@@ -97,32 +97,6 @@ final class DiagnosticReporterSpec: XCTestCase {
         XCTAssertTrue(published is DiagnosticInit)
     }
 
-    func testLastStatsSent() {
-        let tst = TestContext()
-        let now = Date().millisSince1970
-        let stats = DiagnosticStats(id: tst.diagnosticId, creationDate: now, dataSinceDate: now, droppedEvents: 0, eventsInLastBatch: 0, streamInits: [])
-        tst.cachingMock.lastStats = stats
-        tst.queueResponse(status: 202)
-        tst.queueResponse(status: 202)
-        tst.subject.setMode(.foreground, online: true)
-
-        var published = tst.takeEvent()
-        XCTAssertEqual(published.kind, .diagnosticStats)
-        XCTAssertEqual(published.id.diagnosticId, tst.diagnosticId.diagnosticId)
-        XCTAssertTrue(published is DiagnosticStats)
-        if let published = published as? DiagnosticStats {
-            XCTAssertEqual(published.creationDate, now)
-        }
-
-        published = tst.takeEvent()
-        XCTAssertEqual(published.kind, .diagnosticInit)
-        XCTAssertEqual(published.id.diagnosticId, tst.diagnosticId.diagnosticId)
-        XCTAssertEqual(published.id.sdkKeySuffix, tst.diagnosticId.sdkKeySuffix)
-        XCTAssertTrue(published is DiagnosticInit)
-
-        tst.expectNoEvent()
-    }
-
     func testRetries() {
         let tst = TestContext()
         tst.queueResponse(status: 500)


### PR DESCRIPTION
- [ ] I have added test coverage for new or changed functionality
Removed functionality

- [x] I have followed the repository's [pull request submission guidelines](../blob/v11/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions
Benchtested to confirm behavior and performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes `UserDefaults` persistence and the startup resend path for diagnostics; behavior changes may affect what diagnostic events are emitted across app restarts, though the changes are localized and covered by updated tests.
> 
> **Overview**
> **Diagnostic stats caching is now memory-only.** `DiagnosticCache` no longer persists stats/instance IDs in `UserDefaults`; it keeps counters and `streamInits` in-memory behind a single serial queue and resets them on `getCurrentStatsAndReset()`.
> 
> This removes the `DiagnosticCaching.lastStats` API and the reporter behavior that previously sent a persisted `DiagnosticStats` event before the first `DiagnosticInit`. Tests and Sourcery-generated mocks are updated accordingly, and persistence-related specs are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed7e31eaa40f7277aa851271f99307eb61e659ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->