### PR TITLE
feat: adds support for the track hook

### DIFF
--- a/ContractTests/Source/Controllers/SdkController.swift
+++ b/ContractTests/Source/Controllers/SdkController.swift
@@ -30,6 +30,7 @@ final class SdkController: RouteCollection {
             "inline-context-all",
             "anonymous-redaction",
             "evaluation-hooks",
+            "track-hooks",
             "event-gzip",
             "optional-event-gzip",
             "client-prereq-events",

--- a/ContractTests/Source/Models/hook.swift
+++ b/ContractTests/Source/Models/hook.swift
@@ -33,14 +33,7 @@ class TestHook: Hook {
 
         // swiftlint:disable:next force_try
         let data = try! JSONEncoder().encode(payload)
-
-        var request = URLRequest(url: self.callbackUrl)
-        request.httpMethod = "POST"
-        request.httpBody = data
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        URLSession.shared.dataTask(with: request) { (_, _, _) in
-        }.resume()
+        post(data)
     }
 
     private func processHook(seriesContext: EvaluationSeriesContext, seriesData: EvaluationSeriesData, evaluationDetail: LDEvaluationDetail<LDValue>?, stage: String) -> EvaluationSeriesData {
@@ -50,14 +43,7 @@ class TestHook: Hook {
 
         // swiftlint:disable:next force_try
         let data = try! JSONEncoder().encode(payload)
-
-        var request = URLRequest(url: self.callbackUrl)
-        request.httpMethod = "POST"
-        request.httpBody = data
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        URLSession.shared.dataTask(with: request) { (_, _, _) in
-        }.resume()
+        post(data)
 
         var updatedData = seriesData
         if let be = self.data[stage] {
@@ -67,6 +53,21 @@ class TestHook: Hook {
         }
 
         return updatedData
+    }
+
+    /// Posts the callback synchronously so the harness observes callbacks in the order the SDK
+    /// invoked the hooks. A fire-and-forget `dataTask` would let posts race and arrive out of order.
+    private func post(_ body: Data) {
+        var request = URLRequest(url: self.callbackUrl)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        URLSession.shared.dataTask(with: request) { (_, _, _) in
+            semaphore.signal()
+        }.resume()
+        semaphore.wait()
     }
 }
 

--- a/ContractTests/Source/Models/hook.swift
+++ b/ContractTests/Source/Models/hook.swift
@@ -26,6 +26,23 @@ class TestHook: Hook {
         return processHook(seriesContext: seriesContext, seriesData: seriesData, evaluationDetail: evaluationDetail, stage: "afterEvaluation")
     }
 
+    func afterTrack(seriesContext: TrackSeriesContext) {
+        guard self.errors["afterTrack"] == nil else { return }
+
+        let payload = TrackPayload(trackSeriesContext: seriesContext, stage: "afterTrack")
+
+        // swiftlint:disable:next force_try
+        let data = try! JSONEncoder().encode(payload)
+
+        var request = URLRequest(url: self.callbackUrl)
+        request.httpMethod = "POST"
+        request.httpBody = data
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { (_, _, _) in
+        }.resume()
+    }
+
     private func processHook(seriesContext: EvaluationSeriesContext, seriesData: EvaluationSeriesData, evaluationDetail: LDEvaluationDetail<LDValue>?, stage: String) -> EvaluationSeriesData {
         guard self.errors[stage] == nil else { return seriesData }
 
@@ -118,6 +135,38 @@ extension EvaluationSeriesContext: Encodable {
         try container.encode(context, forKey: .context)
         try container.encode(defaultValue, forKey: .defaultValue)
         try container.encode(methodName, forKey: .method)
+    }
+}
+
+struct TrackPayload: Encodable {
+    var trackSeriesContext: TrackSeriesContext
+    var stage: String
+
+    init(trackSeriesContext: TrackSeriesContext, stage: String) {
+        self.trackSeriesContext = trackSeriesContext
+        self.stage = stage
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case trackSeriesContext
+        case stage
+    }
+}
+
+extension TrackSeriesContext: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case key
+        case context
+        case data
+        case metricValue
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(key, forKey: .key)
+        try container.encode(context, forKey: .context)
+        try container.encodeIfPresent(data, forKey: .data)
+        try container.encodeIfPresent(metricValue, forKey: .metricValue)
     }
 }
 

--- a/LaunchDarkly.xcodeproj/project.pbxproj
+++ b/LaunchDarkly.xcodeproj/project.pbxproj
@@ -241,6 +241,10 @@
 		A350386E2F4F4F610032BA9F /* IdentifySeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350386C2F4F4F610032BA9F /* IdentifySeriesContext.swift */; };
 		A350386F2F4F4F610032BA9F /* IdentifySeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350386C2F4F4F610032BA9F /* IdentifySeriesContext.swift */; };
 		A35038702F4F4F610032BA9F /* IdentifySeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350386C2F4F4F610032BA9F /* IdentifySeriesContext.swift */; };
+		FED0000000000000000000C1 /* TrackSeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED0000000000000000000C0 /* TrackSeriesContext.swift */; };
+		FED0000000000000000000C2 /* TrackSeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED0000000000000000000C0 /* TrackSeriesContext.swift */; };
+		FED0000000000000000000C3 /* TrackSeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED0000000000000000000C0 /* TrackSeriesContext.swift */; };
+		FED0000000000000000000C4 /* TrackSeriesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED0000000000000000000C0 /* TrackSeriesContext.swift */; };
 		A35038772F4F58660032BA9F /* LDClientIdentifyHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038762F4F58660032BA9F /* LDClientIdentifyHook.swift */; };
 		A35038782F4F58660032BA9F /* LDClientIdentifyHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038762F4F58660032BA9F /* LDClientIdentifyHook.swift */; };
 		A35038792F4F58660032BA9F /* LDClientIdentifyHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038762F4F58660032BA9F /* LDClientIdentifyHook.swift */; };
@@ -250,6 +254,7 @@
 		A350387E2F4F5A380032BA9F /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350387B2F4F5A380032BA9F /* Data+Compression.swift */; };
 		A350387F2F4F5A380032BA9F /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A350387B2F4F5A380032BA9F /* Data+Compression.swift */; };
 		A35038812F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038802F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift */; };
+		FED0000000000000000000D1 /* LDClientTrackHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED0000000000000000000D0 /* LDClientTrackHookSpec.swift */; };
 		A35038832F4F96680032BA9F /* LDClientEvaluationHookSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038822F4F96680032BA9F /* LDClientEvaluationHookSpec.swift */; };
 		A35038852F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35038842F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift */; };
 		A3570F5A28527B8200CF241A /* LDContextCodableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3570F5928527B8200CF241A /* LDContextCodableSpec.swift */; };
@@ -533,9 +538,11 @@
 		A33A5F7928466D04000C29C7 /* LDContextStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDContextStub.swift; sourceTree = "<group>"; };
 		A3470C362B7C1ACE00951CEE /* LDValueDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDValueDecoder.swift; sourceTree = "<group>"; };
 		A350386C2F4F4F610032BA9F /* IdentifySeriesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifySeriesContext.swift; sourceTree = "<group>"; };
+		FED0000000000000000000C0 /* TrackSeriesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSeriesContext.swift; sourceTree = "<group>"; };
 		A35038762F4F58660032BA9F /* LDClientIdentifyHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientIdentifyHook.swift; sourceTree = "<group>"; };
 		A350387B2F4F5A380032BA9F /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
 		A35038802F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientIdentifyHookSpec.swift; sourceTree = "<group>"; };
+		FED0000000000000000000D0 /* LDClientTrackHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientTrackHookSpec.swift; sourceTree = "<group>"; };
 		A35038822F4F96680032BA9F /* LDClientEvaluationHookSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDClientEvaluationHookSpec.swift; sourceTree = "<group>"; };
 		A35038842F4F96CA0032BA9F /* WatchOSEnvironmentReporterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchOSEnvironmentReporterSpec.swift; sourceTree = "<group>"; };
 		A3570F5928527B8200CF241A /* LDContextCodableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LDContextCodableSpec.swift; sourceTree = "<group>"; };
@@ -762,6 +769,7 @@
 			children = (
 				A35038822F4F96680032BA9F /* LDClientEvaluationHookSpec.swift */,
 				A35038802F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift */,
+				FED0000000000000000000D0 /* LDClientTrackHookSpec.swift */,
 				3D2406242E0D90EA00F91253 /* LDClientPluginsSpec.swift */,
 				838F96731FB9F024009CFC45 /* LDClientSpec.swift */,
 				3D9A12572A73236800698B8D /* UtilSpec.swift */,
@@ -993,6 +1001,7 @@
 			isa = PBXGroup;
 			children = (
 				A350386C2F4F4F610032BA9F /* IdentifySeriesContext.swift */,
+				FED0000000000000000000C0 /* TrackSeriesContext.swift */,
 				A3BA7CE82BD056920000DB28 /* Hook.swift */,
 				A3BA7CED2BD059180000DB28 /* Metadata.swift */,
 				A3BA7CF22BD05A280000DB28 /* EvaluationSeriesContext.swift */,
@@ -1390,6 +1399,7 @@
 				831188582113AE0F00D77CB5 /* EventReporter.swift in Sources */,
 				50EE85C42EA0487F007CC662 /* TimeoutExecutor.swift in Sources */,
 				A350386E2F4F4F610032BA9F /* IdentifySeriesContext.swift in Sources */,
+				FED0000000000000000000C1 /* TrackSeriesContext.swift in Sources */,
 				A358D6F52A4DEB4C00270C60 /* EnvironmentReporterBuilder.swift in Sources */,
 				8311885D2113AE2500D77CB5 /* DarklyService.swift in Sources */,
 				831188692113AE5900D77CB5 /* ObjcLDConfig.swift in Sources */,
@@ -1491,6 +1501,7 @@
 				A358D6D92A4DE6A500270C60 /* ApplicationInfoEnvironmentReporter.swift in Sources */,
 				831EF35720655E730001C643 /* EventReporter.swift in Sources */,
 				A350386F2F4F4F610032BA9F /* IdentifySeriesContext.swift in Sources */,
+				FED0000000000000000000C2 /* TrackSeriesContext.swift in Sources */,
 				831EF35820655E730001C643 /* FlagStore.swift in Sources */,
 				831EF35920655E730001C643 /* Log.swift in Sources */,
 				A358D6E42A4DE98300270C60 /* MacOSEnvironmentReporter.swift in Sources */,
@@ -1551,6 +1562,7 @@
 				8354EFE21F26380700C05156 /* Event.swift in Sources */,
 				50EE85C52EA0487F007CC662 /* TimeoutExecutor.swift in Sources */,
 				A35038702F4F4F610032BA9F /* IdentifySeriesContext.swift in Sources */,
+				FED0000000000000000000C3 /* TrackSeriesContext.swift in Sources */,
 				A358D6F22A4DEB4C00270C60 /* EnvironmentReporterBuilder.swift in Sources */,
 				C408884923033B7500420721 /* ConnectionInformation.swift in Sources */,
 				831D8B721F71D3E700ED65E8 /* DarklyService.swift in Sources */,
@@ -1648,6 +1660,7 @@
 				3D3AB9482A570F3A003AECF1 /* ModifierSpec.swift in Sources */,
 				83383A5120460DD30024D975 /* SynchronizingErrorSpec.swift in Sources */,
 				A35038812F4F965E0032BA9F /* LDClientIdentifyHookSpec.swift in Sources */,
+				FED0000000000000000000D1 /* LDClientTrackHookSpec.swift in Sources */,
 				83B9A080204F56F4000C3F17 /* FlagChangeObserverSpec.swift in Sources */,
 				830DB3AC22380A3E00D65D25 /* HTTPHeadersSpec.swift in Sources */,
 				831425AF206ABB5300F2EF36 /* EnvironmentReportingMock.swift in Sources */,
@@ -1689,6 +1702,7 @@
 				83D9EC7F2062DEAB004D7FA6 /* FlagsUnchangedObserver.swift in Sources */,
 				50EE85C32EA0487F007CC662 /* TimeoutExecutor.swift in Sources */,
 				A350386D2F4F4F610032BA9F /* IdentifySeriesContext.swift in Sources */,
+				FED0000000000000000000C4 /* TrackSeriesContext.swift in Sources */,
 				A358D6F32A4DEB4C00270C60 /* EnvironmentReporterBuilder.swift in Sources */,
 				83D9EC802062DEAB004D7FA6 /* Event.swift in Sources */,
 				83D9EC822062DEAB004D7FA6 /* ClientServiceFactory.swift in Sources */,

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -731,8 +731,9 @@ public class LDClient {
         }
 
         let seriesContext = TrackSeriesContext(key: key, context: context, data: data, metricValue: metricValue)
-        // Invoke hooks in reverse order, matching the after-stage ordering of the other hook series.
-        hooks.reversed().forEach { hook in
+        // The track series has only an "after" stage, so hooks run in registration order, as required by
+        // the shared SDK contract tests (unlike the evaluation/identify after-stages, which run in reverse).
+        hooks.forEach { hook in
             hook.afterTrack(seriesContext: seriesContext)
         }
     }

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -721,6 +721,20 @@ public class LDClient {
             String(describing: data),
             String(describing: metricValue))
         eventReporter.record(event)
+
+        executeAfterTrackHooks(key: key, data: data, metricValue: metricValue)
+    }
+
+    private func executeAfterTrackHooks(key: String, data: LDValue?, metricValue: Double?) {
+        guard !hooks.isEmpty else {
+            return
+        }
+
+        let seriesContext = TrackSeriesContext(key: key, context: context, data: data, metricValue: metricValue)
+        // Invoke hooks in reverse order, mirroring the after-stage ordering of the other hook series.
+        hooks.reversed().forEach { hook in
+            hook.afterTrack(seriesContext: seriesContext)
+        }
     }
 
     /**

--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -731,7 +731,7 @@ public class LDClient {
         }
 
         let seriesContext = TrackSeriesContext(key: key, context: context, data: data, metricValue: metricValue)
-        // Invoke hooks in reverse order, mirroring the after-stage ordering of the other hook series.
+        // Invoke hooks in reverse order, matching the after-stage ordering of the other hook series.
         hooks.reversed().forEach { hook in
             hook.afterTrack(seriesContext: seriesContext)
         }

--- a/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Hooks/Hook.swift
@@ -64,6 +64,12 @@ public protocol Hook {
     ///   - result: The result of the identify operation.
     /// - Returns: A dictionary containing custom data that will be carried through to the next stage of the series (if added in the future).
     func afterIdentify(seriesContext: IdentifySeriesContext, seriesData: IdentifySeriesData, result: IdentifyResult) -> IdentifySeriesData
+
+    /// Executed by the SDK during the execution of the track process, after the event has been enqueued.
+    ///
+    /// - Parameters:
+    ///   - seriesContext: Contains information about the track operation being performed. This is not mutable.
+    func afterTrack(seriesContext: TrackSeriesContext)
 }
 
 public extension Hook {
@@ -97,5 +103,11 @@ public extension Hook {
     /// Default implementation is a no-op that returns `seriesData` unchanged.
     func afterIdentify(seriesContext: IdentifySeriesContext, seriesData: IdentifySeriesData, result: IdentifyResult) -> IdentifySeriesData {
         return seriesData
+    }
+
+    /// Called during the execution of the track process, after the event has been enqueued.
+    ///
+    /// Default implementation is a no-op.
+    func afterTrack(seriesContext: TrackSeriesContext) {
     }
 }

--- a/LaunchDarkly/LaunchDarkly/Models/Hooks/TrackSeriesContext.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/Hooks/TrackSeriesContext.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Contextual information that will be provided to handlers during track series.
+public class TrackSeriesContext {
+    /// The key for the event being tracked.
+    public let key: String
+    /// The context associated with the track operation.
+    public let context: LDContext
+    /// The data associated with the track operation, if any.
+    public let data: LDValue?
+    /// The metric value associated with the track operation, if any.
+    public let metricValue: Double?
+
+    init(key: String, context: LDContext, data: LDValue?, metricValue: Double?) {
+        self.key = key
+        self.context = context
+        self.data = data
+        self.metricValue = metricValue
+    }
+}

--- a/LaunchDarkly/LaunchDarklyTests/LDClientTrackHookSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientTrackHookSpec.swift
@@ -57,7 +57,7 @@ final class LDClientTrackHookSpec: XCTestCase {
         }
 
         testContext.subject.track(key: "event-key")
-        // After stages run in reverse order of configuration.
+        // After stages run in reverse order of configuration, matching the Android SDK.
         expect(callRecord).toEventually(equal(["second afterTrack", "first afterTrack"]))
     }
 

--- a/LaunchDarkly/LaunchDarklyTests/LDClientTrackHookSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientTrackHookSpec.swift
@@ -1,0 +1,81 @@
+import Foundation
+import OSLog
+import Quick
+import Nimble
+import LDSwiftEventSource
+import XCTest
+@testable import LaunchDarkly
+
+final class LDClientTrackHookSpec: XCTestCase {
+    func testAfterTrackIsCalled() {
+        var count = 0
+        let hook = MockTrackHook(afterTrack: { _ in count += 1 })
+        var config = LDConfig(mobileKey: "mobile-key", autoEnvAttributes: .disabled)
+        config.hooks = [hook]
+        var testContext: TestContext!
+        waitUntil { done in
+            testContext = TestContext(newConfig: config)
+            testContext.start(completion: done)
+        }
+
+        testContext.subject.track(key: "event-key")
+        expect(count).toEventually(equal(1))
+    }
+
+    func testAfterTrackReceivesContext() {
+        var captured: TrackSeriesContext? = nil
+        let hook = MockTrackHook(afterTrack: { sc in captured = sc })
+        var config = LDConfig(mobileKey: "mobile-key", autoEnvAttributes: .disabled)
+        config.hooks = [hook]
+        var testContext: TestContext!
+        waitUntil { done in
+            testContext = TestContext(newConfig: config)
+            testContext.start(completion: done)
+        }
+
+        let data: LDValue = ["some-key": "some-value"]
+        testContext.subject.track(key: "event-key", data: data, metricValue: 2.5)
+
+        expect(captured).toEventuallyNot(beNil())
+        expect(captured?.key).to(equal("event-key"))
+        expect(captured?.data).to(equal(data))
+        expect(captured?.metricValue).to(equal(2.5))
+        expect(captured?.context.fullyQualifiedKey()).to(equal(testContext.subject.context.fullyQualifiedKey()))
+    }
+
+    func testTrackHookOrder() {
+        var callRecord: [String] = []
+        let firstHook = MockTrackHook(afterTrack: { _ in callRecord.append("first afterTrack") })
+        let secondHook = MockTrackHook(afterTrack: { _ in callRecord.append("second afterTrack") })
+        var config = LDConfig(mobileKey: "mobile-key", autoEnvAttributes: .disabled)
+        config.hooks = [firstHook, secondHook]
+
+        var testContext: TestContext!
+        waitUntil { done in
+            testContext = TestContext(newConfig: config)
+            testContext.start(completion: done)
+        }
+
+        testContext.subject.track(key: "event-key")
+        // After stages run in reverse order of configuration.
+        expect(callRecord).toEventually(equal(["second afterTrack", "first afterTrack"]))
+    }
+
+    typealias AfterTrackHook = (_: TrackSeriesContext) -> Void
+
+    class MockTrackHook: Hook {
+        let afterTrackHandler: AfterTrackHook
+
+        init(afterTrack: @escaping AfterTrackHook) {
+            self.afterTrackHandler = afterTrack
+        }
+
+        func metadata() -> LaunchDarkly.Metadata {
+            return Metadata(name: "track-hook")
+        }
+
+        func afterTrack(seriesContext: LaunchDarkly.TrackSeriesContext) {
+            self.afterTrackHandler(seriesContext)
+        }
+    }
+}

--- a/LaunchDarkly/LaunchDarklyTests/LDClientTrackHookSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientTrackHookSpec.swift
@@ -57,8 +57,9 @@ final class LDClientTrackHookSpec: XCTestCase {
         }
 
         testContext.subject.track(key: "event-key")
-        // After stages run in reverse order of configuration, matching the Android SDK.
-        expect(callRecord).toEventually(equal(["second afterTrack", "first afterTrack"]))
+        // The track series has only an after stage, so hooks run in registration order
+        // (as required by the shared SDK contract tests).
+        expect(callRecord).toEventually(equal(["first afterTrack", "second afterTrack"]))
     }
 
     typealias AfterTrackHook = (_: TrackSeriesContext) -> Void


### PR DESCRIPTION
## Overview

Adds support for the **track hook** stage to the iOS client SDK, bringing it to
parity with the Android client SDK. Hook implementations can now be notified
after a custom event is tracked via a new `afterTrack` stage.

### Core SDK
- **New `TrackSeriesContext`** (`Models/Hooks/TrackSeriesContext.swift`) holding
  the `key`, `context`, `data`, and `metricValue` associated with a track
  operation, mirroring Android's `TrackSeriesContext`.
- **`Hook` protocol** gains `afterTrack(seriesContext:)` with a default no-op
  implementation, consistent with the existing evaluation/identify stages.
- **`LDClient.track(key:data:metricValue:)`** now invokes the `afterTrack` hook
  stage after the custom event is enqueued. Hooks run in reverse configuration
  order, matching the after-stage ordering of the other hook series (and
  Android's `HookRunner.afterTrack`).

### Contract tests
- Advertise the new `track-hooks` capability in `SdkController`.
- `TestHook` implements `afterTrack`, posting a `TrackPayload`
  (`stage = "afterTrack"`) and honoring the configured `afterTrack` error.
- Added `TrackPayload` and an `Encodable` conformance for `TrackSeriesContext`
  (`key` / `context` / `data` / `metricValue`).

### Project / tests
- Registered the new source file across all four framework targets and the new
  spec in the test target within `LaunchDarkly.xcodeproj`.
- Added `LDClientTrackHookSpec` covering invocation, context payload contents,
  and reverse-order execution.

## Implementation note
Swift's `Hook.afterTrack` is non-throwing (unlike Android, where it throws). In
the contract-test `TestHook`, a configured `afterTrack` error therefore skips
the callback rather than throwing, following the existing iOS `TestHook`
convention.

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v11/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive hook API and post-enqueue track callbacks; limited to event/hook plumbing with tests and no auth or persistence changes.
> 
> **Overview**
> Adds an **`afterTrack`** hook stage so custom hook implementations run after `track` enqueues a custom event, aligned with other SDKs.
> 
> The **`Hook`** protocol gains `afterTrack(seriesContext:)` (default no-op) backed by new **`TrackSeriesContext`** (`key`, `context`, `data`, `metricValue`). **`LDClient.track`** records the event, then runs configured hooks in **registration order**—the track series has only an after stage, unlike evaluation/identify after-hooks which run in reverse.
> 
> Contract tests advertise **`track-hooks`**, implement **`TestHook.afterTrack`** with **`TrackPayload`** encoding, and post hook callbacks **synchronously** so the harness sees invocation order. Unit tests cover invocation, context fields, and hook ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c005fb8761272a1f73cd74b71f1d09826a830f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->