### PR TITLE
test: fix flaky event_reported_while_polling test

### DIFF
--- a/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/ServiceObjects/FlagSynchronizerSpec.swift
@@ -840,10 +840,11 @@ final class FlagSynchronizerSpec: QuickSpec {
 
                 waitUntil { done in
                     testContext.flagSynchronizer.onSyncComplete = { result in
-                        if case .error(let errorResult) = result {
+                        if case .error(let errorResult) = result,
+                           case .streamEventWhilePolling = errorResult {
                             syncError = errorResult
+                            done()
                         }
-                        done()
                     }
 
                     testContext.flagSynchronizer.testStreamOnMessage(event: "put", messageEvent: MessageEvent(data: data))


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/v11/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Follows up on #486 which addressed other flaky `FlagSynchronizerSpec` polling tests but left a remaining race in `streaming_events__event_reported_while_polling__reports_an_event_error`.

**Describe the solution you've provided**

The `onSyncComplete` closure inside the `waitUntil` block called `done()` for any sync result, including poll-triggered completions from the still-active polling timer. When the 1-second timer fired during the `waitUntil` window, `done()` was called twice — once from the poll result and once from the stream event — producing Nimble's `waitUntil(..) expects its completion closure to be only called once` error.

The fix filters `onSyncComplete` to only call `done()` when the expected `.streamEventWhilePolling` error arrives, ignoring poll results (`.error(.response(nil))` from the unstubbed mock).

**Describe alternatives you've considered**

- Adding a `didCallDone` guard (used in the `LDTimerSpec` fix) — works but would mask the poll result overwriting `syncError` if timing is unlucky.
- Stopping the polling timer before the `waitUntil` block — changes the scenario under test.

**Additional context**

Test-only change; no application code modified.

Link to Devin session: https://app.devin.ai/sessions/e40ffc3296dd45648f86ac10c42b6da5
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in FlagSynchronizerSpec; no application or synchronizer production logic modified.
> 
> **Overview**
> Fixes flakiness in **`streamingProcessingSpec`**’s *event reported while polling* example by tightening when the Nimble **`waitUntil`** completion runs.
> 
> The **`onSyncComplete`** handler no longer calls **`done()`** on every **`.error`** sync result. It now completes only when the error is **`.streamEventWhilePolling`**, so incidental poll completions from the active 1s polling timer during **`waitUntil`** no longer invoke **`done()`** a second time (Nimble’s “completion closure called only once” failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f87c80f96a880fda41c99f5f1b9849fed4a7b173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->