### PR TITLE
fix: add defensive cycle guard to prerequisite evaluation

### DIFF
--- a/ContractTests/Source/Controllers/SdkController.swift
+++ b/ContractTests/Source/Controllers/SdkController.swift
@@ -34,6 +34,7 @@ final class SdkController: RouteCollection {
             "event-gzip",
             "optional-event-gzip",
             "client-prereq-events",
+            "client-prereq-cycle-detection",
             "polling-gzip",
             "client-per-context-summaries"
         ]

--- a/LaunchDarkly/LaunchDarkly/LDClientVariation.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClientVariation.swift
@@ -169,13 +169,36 @@ extension LDClient {
     }
 
     private func variationDetailInternal<T>(_ flagKey: LDFlagKey, _ defaultValue: T, needsReason: Bool, methodName: String) -> LDEvaluationDetail<T> where T: Decodable, T: LDValueConvertible {
+        var visited: Set<String>? = nil
+        return variationDetailInternal(flagKey, defaultValue, needsReason: needsReason, methodName: methodName, visited: &visited)
+    }
+
+    private func variationDetailInternal<T>(_ flagKey: LDFlagKey, _ defaultValue: T, needsReason: Bool, methodName: String, visited: inout Set<String>?) -> LDEvaluationDetail<T> where T: Decodable, T: LDValueConvertible {
         return evaluateWithHooks(flagKey: flagKey, defaultValue: defaultValue, methodName: methodName) {
             var result: LDEvaluationDetail<T>
             let featureFlag = flagStore.featureFlag(for: flagKey)
             if let featureFlag = featureFlag {
-                featureFlag.prerequisites?.forEach { prereqFlagKey in
-                    // recurse on prerequisites to emulate prereq evaluations occurring with desirable side effects such as events for prereqs
-                    _ = variationDetailInternal(prereqFlagKey, LDValue.null, needsReason: needsReason, methodName: methodName)
+                if let prerequisites = featureFlag.prerequisites, !prerequisites.isEmpty {
+                    // Recurse on prerequisites to emulate prereq evaluations occurring with desirable side effects
+                    // such as events for prereqs.
+                    //
+                    // `visited` tracks the chain of prerequisite dependencies from the top-level evaluation to
+                    // (but not including) the current flag. The set is allocated lazily: it stays `nil` until we
+                    // descend into the first flag whose `prerequisites` are non-empty, so a variation call on a
+                    // leaf flag pays no heap allocation for cycle bookkeeping.
+                    if visited == nil {
+                        visited = Set<String>()
+                    }
+                    visited!.insert(flagKey)
+                    defer { visited!.remove(flagKey) }
+                    for prereqFlagKey in prerequisites {
+                        if visited!.contains(prereqFlagKey) {
+                            // Cyclic edge: skip descent, continue with remaining prerequisites at this level.
+                            // The requested flag's value and reason (below) are unaffected.
+                            continue
+                        }
+                        _ = variationDetailInternal(prereqFlagKey, LDValue.null, needsReason: needsReason, methodName: methodName, visited: &visited)
+                    }
                 }
 
                 if featureFlag.value == .null {

--- a/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift
@@ -799,6 +799,69 @@ final class LDClientSpec: QuickSpec {
                     expect(events[7].key) == "flagABD"
                 }
             }
+            // Cycle-detection tests exercise the ancestor-set cycle guard added to
+            // variationDetailInternal. Prior to that guard, any of these flag configurations would
+            // cause unbounded recursion during a variation() call. The tests set up a cyclic
+            // prerequisite graph and evaluate one flag on the cycle, asserting (a) the SDK returns
+            // the flag's cached value unchanged and (b) the emitted evaluation events reflect
+            // exactly one recording per cycle-safe descent.
+            context("flag store contains cyclic prerequisites") {
+                var events = [FeatureEvent]()
+                beforeEach {
+                    events = []
+                    testContext.eventReporterMock.recordFlagEvaluationEventsCallback = {
+                        let args = testContext.eventReporterMock.recordFlagEvaluationEventsReceivedArguments!
+                        events.append(FeatureEvent(key: args.flagKey, context: args.context, value: args.value, defaultValue: args.defaultValue, featureFlag: args.featureFlag, includeReason: args.includeReason, isDebug: false))
+                    }
+                }
+                it("skips self-loop prerequisite and returns cached value") {
+                    let flagA = FeatureFlag(flagKey: "flagA", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagA"])
+                    testContext.flagStoreMock.replaceStore(newStoredItems: StoredItems(items: ["flagA": flagA]))
+                    // Requirement 1.2.5.1: the requested flag's cached value is returned unchanged.
+                    expect(testContext.subject.boolVariation(forKey: "flagA", defaultValue: false)) == true
+                    // The self-prereq is cycle-skipped, so only the top-level evaluation records an event.
+                    expect(events.map { $0.key }) == ["flagA"]
+                }
+                it("handles a two-cycle evaluating A") {
+                    let flagA = FeatureFlag(flagKey: "flagA", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagB"])
+                    let flagB = FeatureFlag(flagKey: "flagB", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagA"])
+                    testContext.flagStoreMock.replaceStore(newStoredItems: StoredItems(items: ["flagA": flagA, "flagB": flagB]))
+                    expect(testContext.subject.boolVariation(forKey: "flagA", defaultValue: false)) == true
+                    // A -> B -> [A skipped]. Events emitted deepest-first: B (as prereq of A), then A.
+                    expect(events.map { $0.key }) == ["flagB", "flagA"]
+                }
+                it("handles a two-cycle evaluating B") {
+                    let flagA = FeatureFlag(flagKey: "flagA", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagB"])
+                    let flagB = FeatureFlag(flagKey: "flagB", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagA"])
+                    testContext.flagStoreMock.replaceStore(newStoredItems: StoredItems(items: ["flagA": flagA, "flagB": flagB]))
+                    expect(testContext.subject.boolVariation(forKey: "flagB", defaultValue: false)) == true
+                    // Symmetric: same graph, entry from B. Events: A (as prereq of B), then B.
+                    expect(events.map { $0.key }) == ["flagA", "flagB"]
+                }
+                it("handles a three-cycle") {
+                    let flagA = FeatureFlag(flagKey: "flagA", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagB"])
+                    let flagB = FeatureFlag(flagKey: "flagB", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagC"])
+                    let flagC = FeatureFlag(flagKey: "flagC", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagA"])
+                    testContext.flagStoreMock.replaceStore(newStoredItems: StoredItems(items: ["flagA": flagA, "flagB": flagB, "flagC": flagC]))
+                    expect(testContext.subject.boolVariation(forKey: "flagA", defaultValue: false)) == true
+                    // A -> B -> C -> [A skipped]. Events emitted deepest-first: C, B, A.
+                    expect(events.map { $0.key }) == ["flagC", "flagB", "flagA"]
+                }
+                it("emits the shared descendant once per path in a non-cyclic diamond") {
+                    // Diamond: A -> [B, C], B -> [D], C -> [D]. Not a cycle. Ancestor-set (current-path)
+                    // semantics must let D be reached on each of the two independent paths — so D emits
+                    // twice. A naive "visited across the whole walk" implementation would incorrectly
+                    // count D only once; this case guards against that regression.
+                    let flagA = FeatureFlag(flagKey: "flagA", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagB", "flagC"])
+                    let flagB = FeatureFlag(flagKey: "flagB", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagD"])
+                    let flagC = FeatureFlag(flagKey: "flagC", value: LDValue.bool(true), trackEvents: false, trackReason: false, prerequisites: ["flagD"])
+                    let flagD = FeatureFlag(flagKey: "flagD", value: LDValue.bool(true), trackEvents: false, trackReason: false)
+                    testContext.flagStoreMock.replaceStore(newStoredItems: StoredItems(items: ["flagA": flagA, "flagB": flagB, "flagC": flagC, "flagD": flagD]))
+                    expect(testContext.subject.boolVariation(forKey: "flagA", defaultValue: false)) == true
+                    // Events (deepest-first per path): D (via B), B, D (via C), C, A. D appears twice.
+                    expect(events.map { $0.key }) == ["flagD", "flagB", "flagD", "flagC", "flagA"]
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds defensive cycle detection to the recursive prerequisite walk in `LDClient.variationDetailInternal`, bringing the iOS client SDK's behavior into line with the LaunchDarkly server SDK evaluators, which have handled cyclic prerequisite graphs gracefully for years.

Tracker: [SDK-2704](https://launchdarkly.atlassian.net/browse/SDK-2704). Parent: [SDK-2695](https://launchdarkly.atlassian.net/browse/SDK-2695). Spec change: [sdk-specs#246](https://github.com/launchdarkly/sdk-specs/pull/246) (CSPE 1.2.5, 1.2.5.1, 1.2.5.2). Contract-test coverage: [sdk-test-harness#384](https://github.com/launchdarkly/sdk-test-harness/pull/384) (merged in v2.38.0). Companion Android fix: [android-client-sdk#377](https://github.com/launchdarkly/android-client-sdk/pull/377).

## Background

The LaunchDarkly service validates prerequisite graphs on every mutation and rejects any change that would produce a cycle, so under normal operation the SDK does not see a cyclic prerequisite graph. Server-side SDK evaluators nonetheless carry defensive cycle detection for exceptional cases — for example, delivery of updates out of order or a persisted state loaded from disk that predates a subsequent correction. This PR extends the same defensive posture to the iOS client SDK.

## The fix

`variationDetailInternal` now threads a lazily-allocated `Set<String>?` through the recursion carrying the flag keys on the current evaluation path. Before descending into a prerequisite, the walker checks whether that key is already on the path; if so, it skips that edge and continues with remaining prerequisites at the same level.

- **Lazy allocation**: variation calls on prereq-less flags (the common case) allocate zero collections. The `Set<String>` is created only when the walker descends into a prerequisite for the first time in a call, then reused for the rest of the walk.
- **Mutable `insert` / `defer remove`**: no per-descent copy. `insert(flagKey)` before recursing, `defer { visited!.remove(flagKey) }` for guaranteed cleanup — the invariant "the set contains exactly the current path" holds even under early exits.
- **Ancestor-set (current-path) semantics** — this is deliberate. A prerequisite reached via multiple non-cyclic paths (a diamond `A -> [B, C], B -> [D], C -> [D]`) is not a cycle; each path should emit its own prerequisite event. A global visited-set would silently drop the second event; the ancestor-set pattern correctly emits D twice. There is a unit test guarding this.

The public 4-argument `variationDetailInternal` signature is preserved as a thin wrapper that declares `var visited: Set<String>? = nil` and calls the new 5-argument overload — none of the 12 top-level variation methods (`boolVariation`, `intVariation`, etc.) need to change.

## Caller-visible behavior on a cycle

The requested flag returns its cached value and reason unchanged. A client-side prerequisite cycle is not surfaced as `MALFORMED_FLAG` and does not fall back to the caller-provided default value. This differs from server-side behavior — the client already holds an authoritative pre-evaluated result from the server; only the ancillary event walk is affected by the cycle.

## Files changed

- `LaunchDarkly/LaunchDarkly/LDClientVariation.swift` — cycle guard in `variationDetailInternal`. 4-argument public signature preserved as a wrapper; new 5-argument overload carries the `inout Set<String>?`.
- `LaunchDarkly/LaunchDarklyTests/LDClientSpec.swift` — 5 new Quick/Nimble tests under a new `context("flag store contains cyclic prerequisites")`: self-loop, two-cycle (evaluating each end), three-cycle, and a non-cyclic diamond that asserts the shared descendant emits an event for each path (the ancestor-set regression fence).
- `ContractTests/Source/Controllers/SdkController.swift` — declares `client-prereq-cycle-detection` so the matching contract tests in sdk-test-harness v2.38.0+ activate for this SDK.

## Verification

- **Unit tests**: `swift test` → 615 tests, 0 failures. The 5 new cycle-detection tests are visible in the log and passing.
- **Contract tests locally** against harness v2.38.0: `make contract-tests` → 838 total, 15 skipped, 823 ran, all passed. Both new suites (`events/prerequisite events handle cycles` and `events/summary events/prerequisites/handles cycles`) fire and pass — 15 subtests total between them.

## Changelog

> Updated prerequisite evaluation event emission to match server SDK behavior for cyclic prerequisite graphs.

[SDK-2704]: https://launchdarkly.atlassian.net/browse/SDK-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2695]: https://launchdarkly.atlassian.net/browse/SDK-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core flag evaluation and prerequisite event emission; behavior change is defensive and well-tested but affects analytics paths on malformed graphs.
> 
> **Overview**
> Adds **defensive cycle detection** to the recursive prerequisite walk in `variationDetailInternal`, aligning client behavior with server SDKs and CSPE **1.2.5**.
> 
> Before descending into a prerequisite, the walker tracks flag keys on the **current path** in a lazily allocated `Set` (no extra allocation for flags without prerequisites). If a prerequisite key is already on the path, that edge is **skipped**; the evaluated flag still returns its **cached value and reason** unchanged. **Ancestor-set** semantics preserve correct behavior on **diamond** graphs (shared descendants still emit prerequisite events once per path).
> 
> Adds Quick/Nimble coverage for self-loops, 2- and 3-cycles, and the diamond regression case. Contract tests advertise capability **`client-prereq-cycle-detection`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd39a6286c254d179908efe4bc8dd197a2e443b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->