### PR TITLE
feat: guard the primary mobile key against the secondary keys

### DIFF
--- a/LaunchDarkly/LaunchDarkly/LDClient.swift
+++ b/LaunchDarkly/LaunchDarkly/LDClient.swift
@@ -838,6 +838,8 @@ public class LDClient {
         mobileKeys[LDConfig.Constants.primaryEnvironmentName] = config.mobileKey
         for (name, mobileKey) in mobileKeys {
             var internalConfig = config
+            // Assigned rather than set through setMobileKey, which would reject a secondary environment's own key. The
+            // copy describes one environment, so the key it holds is that environment's whichever one it is.
             internalConfig.mobileKey = mobileKey
             let instance: LDClient = LDClient(serviceFactory: serviceFactory, configuration: internalConfig, startContext: context, completion: completionCheck)
             instancesQueue.sync(flags: .barrier) {

--- a/LaunchDarkly/LaunchDarkly/Models/LDConfig.swift
+++ b/LaunchDarkly/LaunchDarkly/Models/LDConfig.swift
@@ -301,7 +301,11 @@ public struct LDConfig {
     }
 
     /// The Mobile key from your [LaunchDarkly Account](app.launchdarkly.com) settings (on the left at the bottom). If you have multiple projects be sure to choose the correct Mobile key.
-    public var mobileKey: String
+    ///
+    /// Set this with `setMobileKey(_:)`, which rejects a key already naming a secondary environment. The setter is not
+    /// public because it cannot throw, and an environment sharing a mobile key with another is not a configuration the
+    /// SDK can act on.
+    public internal(set) var mobileKey: String
 
     /// The base url for making feature flag requests. Do not change unless instructed by LaunchDarkly.
     public var baseUrl: URL = Defaults.baseUrl
@@ -457,6 +461,23 @@ public struct LDConfig {
         var internalMobileKeys = getSecondaryMobileKeys()
         internalMobileKeys[LDConfig.Constants.primaryEnvironmentName] = mobileKey
         return internalMobileKeys
+    }
+
+    /**
+     Sets the mobile key for the primary environment. Throws `LDInvalidArgumentError` if the key already names one of
+     the secondary environments, since each environment must have its own.
+
+     Setting the key and setting the secondary keys are checked against each other whichever order they are done in, so
+     that a configuration cannot arrive at a state neither call would have accepted on its own.
+
+     - parameter newMobileKey: The mobile key for the primary environment.
+     */
+    public mutating func setMobileKey(_ newMobileKey: String) throws {
+        if getSecondaryMobileKeys().values.contains(newMobileKey) {
+            throw(LDInvalidArgumentError("The primary environment key cannot be in the secondary mobile keys."))
+        }
+
+        mobileKey = newMobileKey
     }
 
     /**

--- a/LaunchDarkly/LaunchDarkly/ObjectiveC/ObjcLDConfig.swift
+++ b/LaunchDarkly/LaunchDarkly/ObjectiveC/ObjcLDConfig.swift
@@ -14,9 +14,20 @@ public final class ObjcLDConfig: NSObject {
     var config: LDConfig
 
     /// The Mobile key from your [LaunchDarkly Account](app.launchdarkly.com) settings (on the left at the bottom). If you have multiple projects be sure to choose the correct Mobile key.
+    ///
+    /// Read only, because setting it can fail: use `setMobileKey(_:)`.
     @objc public var mobileKey: String {
-        get { config.mobileKey }
-        set { config.mobileKey = newValue }
+        config.mobileKey
+    }
+
+    /**
+     Sets the mobile key for the primary environment. Throws if the key already names one of the secondary
+     environments, since each environment must have its own.
+
+     - parameter key: The mobile key for the primary environment.
+     */
+    @objc public func setMobileKey(_ key: String) throws {
+        try config.setMobileKey(key)
     }
 
     /// The url for making feature flag requests. Do not change unless instructed by LaunchDarkly.

--- a/LaunchDarkly/LaunchDarklyTests/Models/LDConfigSpec.swift
+++ b/LaunchDarkly/LaunchDarklyTests/Models/LDConfigSpec.swift
@@ -117,6 +117,27 @@ final class LDConfigSpec: XCTestCase {
         }
     }
 
+    func testSetMobileKeyRejectsASecondaryEnvironmentsKey() {
+        var config = LDConfig(mobileKey: LDConfig.Constants.mockMobileKey, autoEnvAttributes: .disabled)
+        try! config.setSecondaryMobileKeys(["other": LDConfig.Constants.alternateMobileKey])
+
+        // Each environment must have its own key, and setSecondaryMobileKeys rejects the same collision the other way
+        // around, so neither order of the two calls can arrive at it.
+        XCTAssertThrowsError(try config.setMobileKey(LDConfig.Constants.alternateMobileKey)) { error in
+            XCTAssertTrue(error is LDInvalidArgumentError)
+        }
+        XCTAssertEqual(config.mobileKey, LDConfig.Constants.mockMobileKey)
+    }
+
+    func testSetMobileKeyAcceptsAKeyNoSecondaryEnvironmentUses() {
+        var config = LDConfig(mobileKey: LDConfig.Constants.mockMobileKey, autoEnvAttributes: .disabled)
+        try! config.setSecondaryMobileKeys(["other": LDConfig.Constants.alternateMobileKey])
+
+        try! config.setMobileKey("another-mobile-key")
+
+        XCTAssertEqual(config.mobileKey, "another-mobile-key")
+    }
+
     func testMinimaInitDebug() {
         let config = LDConfig(mobileKey: LDConfig.Constants.mockMobileKey, autoEnvAttributes: .disabled, isDebugBuild: true)
         XCTAssertEqual(config.minima.flagPollingInterval, LDConfig.Minima.Debug.flagPollingInterval)


### PR DESCRIPTION
setSecondaryMobileKeys rejects a key the primary environment already uses, but the primary key could then be assigned to one of those keys afterwards, reaching a state neither call would have accepted. Setting it now goes through setMobileKey, which makes the same check the other way around, so the order the two are called in no longer decides whether the configuration is validated.

The property stays settable within the SDK, which assigns it on a copy of the config for each environment it starts.

BREAKING CHANGE: LDConfig.mobileKey is read-only outside the SDK. Assignments to it become calls to the throwing setMobileKey.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/v11/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Closes a validation gap where `setSecondaryMobileKeys` rejected a primary key collision, but assigning the primary key afterward could still create the same invalid config.
> 
> **`LDConfig.mobileKey` is now `public internal(set)`**, with a new throwing `setMobileKey(_:)` that rejects keys already used by a secondary environment. The Objective-C wrapper mirrors this. The SDK still assigns `mobileKey` directly on per-environment config copies during startup.
> 
> **Breaking change:** external assignments to `mobileKey` must become `try setMobileKey(...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0008e5806c63c057c8eca1889b174b6486a043b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->